### PR TITLE
Add support for disabling / enabling packages during layer init

### DIFF
--- a/src/proton/core.cljs
+++ b/src/proton/core.cljs
@@ -81,7 +81,7 @@
 
         ;; wipe existing config
         (atom-env/insert-process-step! "Wiping existing configuration")
-        (doall (map atom-env/unset-config! (atom-env/get-all-settings)))
+        (doall (map atom-env/unset-config! (filter #(not (= "core.disabledPackages" %)) (atom-env/get-all-settings))))
         (atom-env/mark-last-step-as-completed!)
 
         ;; Init layers

--- a/src/proton/core.cljs
+++ b/src/proton/core.cljs
@@ -79,14 +79,16 @@
         ;; make sure core packages are disabled
         (doall (map pm/disable-package (map name all-disabled)))
 
-        (atom-env/insert-process-step! "Initialising layers")
-        (proton/init-layers! all-layers all-configuration)
-        (atom-env/mark-last-step-as-completed!)
-
         ;; wipe existing config
         (atom-env/insert-process-step! "Wiping existing configuration")
         (doall (map atom-env/unset-config! (atom-env/get-all-settings)))
         (atom-env/mark-last-step-as-completed!)
+
+        ;; Init layers
+        (atom-env/insert-process-step! "Initialising layers")
+        (proton/init-layers! all-layers all-configuration)
+        (atom-env/mark-last-step-as-completed!)
+
         ;; set the user config
         (atom-env/insert-process-step! "Applying user configuration")
         (doall (map #(atom-env/set-config! (get % 0) (get % 1)) all-configuration))

--- a/src/proton/core.cljs
+++ b/src/proton/core.cljs
@@ -79,14 +79,14 @@
         ;; make sure core packages are disabled
         (doall (map pm/disable-package (map name all-disabled)))
 
-        ;; wipe existing config
-        (atom-env/insert-process-step! "Wiping existing configuration")
-        (doall (map atom-env/unset-config! (filter #(not (= "core.disabledPackages" %)) (atom-env/get-all-settings))))
-        (atom-env/mark-last-step-as-completed!)
-
         ;; Init layers
         (atom-env/insert-process-step! "Initialising layers")
         (proton/init-layers! all-layers all-configuration)
+        (atom-env/mark-last-step-as-completed!)
+
+        ;; wipe existing config
+        (atom-env/insert-process-step! "Wiping existing configuration")
+        (doall (map atom-env/unset-config! (filter #(not (= "core.disabledPackages" %)) (atom-env/get-all-settings))))
         (atom-env/mark-last-step-as-completed!)
 
         ;; set the user config

--- a/src/proton/lib/atom.cljs
+++ b/src/proton/lib/atom.cljs
@@ -98,6 +98,15 @@
   (.log js/console (str "Setting " selector " to " (clj->js value)))
   (.set config selector (clj->js value)))
 
+(defn add-to-config! [selector value]
+  (let [previous-config (js->clj (.get config selector))]
+    (set-config! selector (conj previous-config value))))
+
+(defn remove-val-from-config! [selector value]
+  (let [config (js->clj (.get config selector))
+        new-config (filter #(not (= value %)) config)]
+      (set-config! selector new-config)))
+
 (defn unset-config! [selector]
   (.unset config selector))
 

--- a/src/proton/lib/package_manager.cljs
+++ b/src/proton/lib/package_manager.cljs
@@ -27,13 +27,20 @@
   (let [pkgs (set (into [] (map keyword (get-all-packages))))]
     (filter #(if (not (contains? pkgs %)) %) all-packages)))
 
+(defn is-activated? [package-name]
+  (let [package-names (->> (.getActivePackages packages) js->clj (map #(.-name %)))
+        filtered-packages (filter #(= package-name %) package-names)]
+    (> (count filtered-packages) 0)))
+
 (defn enable-package [package-name]
   (println (str "enabling package " package-name))
   (.enablePackage packages package-name))
 
 (defn disable-package [package-name]
-  (println (str "disabling package " package-name))
-  (.disablePackage packages package-name))
+  (if (is-activated? package-name)
+    (do
+      (println (str "disabling package " package-name))
+      (.disablePackage packages package-name))))
 
 (defn reload-package [package-name]
   (disable-package package-name)

--- a/src/proton/lib/package_manager.cljs
+++ b/src/proton/lib/package_manager.cljs
@@ -1,7 +1,8 @@
 (ns proton.lib.package_manager
   (:require-macros [cljs.core.async.macros :refer [go go-loop]])
   (:require [cljs.nodejs :as node]
-            [cljs.core.async :as async :refer [close! chan put! pub sub unsub >! <!]]))
+            [cljs.core.async :as async :refer [close! chan put! pub sub unsub >! <!]]
+            [proton.lib.atom :as atom]))
 
 (def sys (node/require "sys"))
 (def child-process (node/require "child_process"))
@@ -27,9 +28,11 @@
     (filter #(if (not (contains? pkgs %)) %) all-packages)))
 
 (defn enable-package [package-name]
+  (println (str "enabling package " package-name))
   (.enablePackage packages package-name))
 
 (defn disable-package [package-name]
+  (println (str "disabling package " package-name))
   (.disablePackage packages package-name))
 
 (defn reload-package [package-name]


### PR DESCRIPTION
- `disable-package` now checks if a package is already disabled before attempting to disable it (resulted in duplicate `disabledPackages` entries before)
- Excluded `disabledPackages` from config wipe
- Changed `relative-numbers` and `tabs` to new disable/enable package logic