### PR TITLE
Simple mode implementation + mode keybindings

### DIFF
--- a/HOW-TO-LAYER.md
+++ b/HOW-TO-LAYER.md
@@ -184,10 +184,11 @@ in our example `, t p` and `<spc> m t p` execute same action.
 To define mode you should use `(defmethod describe-mode :{{your-layer}} [] {})`. For now following options are available.
 
 - `:mode-name` - __keyword__ to define name of the mode. This option is required.
-- `:atom-grammars` - __vector of strings__ or __single string__ name of grammar to capture.
-- `:file-extensions` - __vector of regular__ expressions to detect filename.
+- `:atom-grammars` - __vector of strings__ or __single string__ name of grammar to capture, e.g. "Clojure", ["GitHub Flawored Markdown"]
+- `:atom-scope` - __vector of strings__ or __single string__ name of the grammar scope to capture, e.g. "source.clojure", ["source.gfm"]
+- `:file-extensions` - __vector of regular__ expressions to detect filename extension, e.g. [#"\.cljs$", #"\.clj"]
 - `:mode-keybindings` - map description of keybindings used for this mode. Format is the same as for `get-keybindings` function.
-- `:init` - __function__ to initialize on mode activation
+- `:init` - __function__ to initialize on mode activation.
 
 
 ### Testing your layer

--- a/HOW-TO-LAYER.md
+++ b/HOW-TO-LAYER.md
@@ -29,6 +29,10 @@ Creating a layer is very simple. Here is how your base sceleton could look like 
 (defmethod get-keymaps :{{your-layer}}
   []
   [])
+
+(defmethod describe-mode :{{your-layer}}
+  []
+  {})
 ```
 
 #### namespace
@@ -153,6 +157,37 @@ Here we return a keymap with `:selector` `.tree-view`, meaning that whatever com
 The keymap specifies that once the user hits `escape` inside that `.tree-view`, dispatch `tree-view:toggle`.
 
 _Custom functions and custom targets are not supported yet_.
+
+#### mode keybindings
+
+you can specify keybindings related to special file types and grammars using `describe-mode` function. This keybindings will be available by `<spc> m` orc short alias `,`. For example:
+
+```clj
+(defmethod describe-mode :lang/clojure []
+  {:mode-name :clojure
+   :atom-grammars ["Clojure"]
+   :file-extensions [#"\.proton$"]
+   :mode-keybindings
+   {:t {:category "toggles"
+        :p {:action "parinfer:toggleMode" :title "Toggle Parinfer Mode"}}}})
+```
+
+What we did here is, created new mode called `:clojure` which will be activated
+when opened file grammar is `"Clojure"` or filename ends with `.proton`. Also we
+define keybinding within `:mode-keybindings` keyword to toggle parinfer mode by `t p` keys. Now when we open
+clojure file or __.proton__ and hit `<spc> m` we'll see special keymaps available for our mode.
+Now we can toggle parinfer mode using `<spc> m t p`. Also all mode keybindings can be executed by short alias `,` instead of `<spc> m`,
+in our example `, t p` and `<spc> m t p` execute same action.
+
+#### mode options
+
+To define mode you should use `(defmethod describe-mode :{{your-layer}} [] {})`. For now following options are available.
+
+- `:mode-name` - __keyword__ to define name of the mode. This option is required.
+- `:atom-grammars` - __vector of strings__ or __single string__ name of grammar to capture.
+- `:file-extensions` - __vector of regular__ expressions to detect filename.
+- `:mode-keybindings` - map description of keybindings used for this mode. Format is the same as for `get-keybindings` function.
+- `:init` - __function__ to initialize on mode activation
 
 
 ### Testing your layer

--- a/src/cljs/proton/core.cljs
+++ b/src/cljs/proton/core.cljs
@@ -4,6 +4,7 @@
             [proton.lib.atom :as atom-env]
             [proton.lib.package_manager :as pm]
             [proton.lib.proton :as proton]
+            [proton.lib.mode :as mode-manager]
             [cljs.nodejs :as node]
             [clojure.string :as string :refer [lower-case upper-case]]
 
@@ -48,8 +49,12 @@
 (def subscriptions (new composite-disposable))
 (swap! disposables conj subscriptions)
 
-(def command-tree (atom {}))
-(def current-chain (atom []))
+(defonce command-tree (atom {}))
+(defonce current-chain (atom []))
+
+(def mode-key :m)
+(defn is-mode-key? [chain-key]
+  (not (nil? (some #{mode-key} chain-key))))
 
 (defn chain [e]
   (let [key-code (helpers/extract-keycode-from-event e)
@@ -66,9 +71,15 @@
             (atom-env/eval-action! @command-tree @current-chain)
             ;; if not, continue chaining
             (let [extracted-chain (get-in @command-tree @current-chain)]
-              (if (nil? extracted-chain)
-                (atom-env/deactivate-proton-mode!)
-                (atom-env/update-bottom-panel (helpers/tree->html extracted-chain)))))))))
+              (cond (nil? extracted-chain) (atom-env/deactivate-proton-mode!)
+                    (is-mode-key? @current-chain)
+                    (do
+                      (if-let [mode-keymap (mode-manager/get-mode-keybindings (atom-env/get-active-editor))]
+                        (do
+                          (swap! command-tree assoc-in [:m] mode-keymap)
+                          (atom-env/update-bottom-panel (helpers/tree->html (get-in @command-tree @current-chain))))
+                        (atom-env/deactivate-proton-mode!)))
+                    :else (atom-env/update-bottom-panel (helpers/tree->html extracted-chain)))))))))
 
 (defn init []
   (go
@@ -142,6 +153,7 @@
                 (atom-env/mark-last-step-as-completed!))))
 
           (atom-env/insert-process-step! "All done!" "")
+          (mode-manager/activate-mode (atom-env/get-active-editor))
           (.setTimeout js/window #(atom-env/hide-modal-panel) 3000))))))
 
 (defn on-space []
@@ -153,6 +165,7 @@
   (.setTimeout js/window #(init) 2000)
   (let [disposable (.onDidMatchBinding keymaps #(if (= "space" (.-keystrokes %)) (on-space)))]
     (swap! disposables conj disposable))
+  (swap! disposables conj (proton/panel-item-subscription))
   (.add subscriptions (.add commands "atom-text-editor.proton-mode" "proton:chain" chain)))
 
 (defn deactivate []

--- a/src/cljs/proton/layers/base.cljs
+++ b/src/cljs/proton/layers/base.cljs
@@ -9,3 +9,4 @@
 (defmulti get-packages dispatch)
 (defmulti get-keybindings dispatch)
 (defmulti get-keymaps dispatch)
+(defmulti describe-mode dispatch)

--- a/src/cljs/proton/layers/core/core.cljs
+++ b/src/cljs/proton/layers/core/core.cljs
@@ -1,5 +1,5 @@
 (ns proton.layers.core.core
-  (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps]])
+  (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps describe-mode]])
   (:require [proton.lib.proton :as proton]
             [proton.lib.package_manager :as package]
             [proton.layers.core.keybindings :refer [keybindings]]
@@ -55,3 +55,4 @@
 (defmethod get-keybindings :core [] @keybindings)
 (defmethod get-keymaps :core [] @keymaps)
 (defmethod get-packages :core [] @packages)
+(defmethod describe-mode :core [] {})

--- a/src/cljs/proton/layers/core/keybindings.cljs
+++ b/src/cljs/proton/layers/core/keybindings.cljs
@@ -77,6 +77,7 @@
                         (do
                           (actions/toggle-relative-lines true)
                           (swap! state assoc-in [:relative-numbers] true))))}}
+          :m {:category "mode"}
           :_ {:category "meta"
               :d {:title "find-dotfile"
                   :fx (fn []

--- a/src/cljs/proton/layers/lang/clojure/README.md
+++ b/src/cljs/proton/layers/lang/clojure/README.md
@@ -5,3 +5,9 @@ This layer adds support for clojure based file editind powered by [parinfer](htt
 ### Install
 
 Add `:lang/clojure` to your layers.
+
+### Key Bindings
+
+|Key Binding                | Description                   |
+|--------------------------:|------------------------------:|
+| <kbd>SPC m t p</kbd>      | toggle Parinfer mode          |

--- a/src/cljs/proton/layers/lang/clojure/core.cljs
+++ b/src/cljs/proton/layers/lang/clojure/core.cljs
@@ -1,8 +1,19 @@
 (ns proton.layers.lang.clojure.core
+  (:require [proton.lib.mode :as mode :refer [define-mode define-keybindings]]
+            [proton.lib.atom :as atom-env :refer [set-grammar]])
   (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps]]))
 
 (defmethod init-layer! :lang/clojure
   [_ config]
+  ()
+  (mode/define-mode :clojure
+     :atom-grammars ["Clojure"]
+     :file-extensions [#"\.proton$"]
+     :init (fn []
+            (atom-env/set-grammar "Clojure")))
+  (mode/define-keybindings :clojure
+    {:t {:category "toggles"
+         :p {:action "parinfer:toggleMode" :title "Toggle Parinfer Mode"}}})
   (println "init clojure"))
 
 (defmethod get-packages :lang/clojure

--- a/src/cljs/proton/layers/lang/clojure/core.cljs
+++ b/src/cljs/proton/layers/lang/clojure/core.cljs
@@ -1,24 +1,28 @@
 (ns proton.layers.lang.clojure.core
   (:require [proton.lib.mode :as mode :refer [define-mode define-keybindings]]
             [proton.lib.atom :as atom-env :refer [set-grammar]])
-  (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps]]))
+  (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps describe-mode]]))
+
+(defn- clojure-mode-init []
+ (atom-env/set-grammar "Clojure"))
 
 (defmethod init-layer! :lang/clojure
   [_ config]
-  ()
-  (mode/define-mode :clojure
-     :atom-grammars ["Clojure"]
-     :file-extensions [#"\.proton$"]
-     :init (fn []
-            (atom-env/set-grammar "Clojure")))
-  (mode/define-keybindings :clojure
-    {:t {:category "toggles"
-         :p {:action "parinfer:toggleMode" :title "Toggle Parinfer Mode"}}})
   (println "init clojure"))
 
 (defmethod get-packages :lang/clojure
   []
   [:Parinfer])
+
+(defmethod describe-mode :lang/clojure []
+  {:mode-name :clojure
+   :atom-grammars ["Clojure"]
+   :file-extensions [#"\.proton$"]
+   :mode-keybindings
+   {:t {:category "toggles"
+        :p {:action "parinfer:toggleMode" :title "Toggle Parinfer Mode"}}}
+   :init clojure-mode-init})
+
 
 (defmethod get-keymaps :lang/clojure [] [])
 (defmethod get-initial-config :lang/clojure [] [])

--- a/src/cljs/proton/layers/lang/julia/core.cljs
+++ b/src/cljs/proton/layers/lang/julia/core.cljs
@@ -1,5 +1,5 @@
 (ns proton.layers.lang.julia.core
-  (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps]]))
+  (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps describe-mode]]))
 
 (defmethod get-initial-config :lang/julia
   []
@@ -25,3 +25,4 @@
 (defmethod get-keybindings :julia [] (get-keybindings :lang/julia))
 (defmethod get-initial-config :julia [] (get-initial-config :lang/julia))
 (defmethod init-layer! :julia [] (init-layer! :lang/julia))
+(defmethod describe-mode :lang/julia [] {})

--- a/src/cljs/proton/layers/lang/latex/core.cljs
+++ b/src/cljs/proton/layers/lang/latex/core.cljs
@@ -1,5 +1,5 @@
 (ns proton.layers.lang.latex.core
-  (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps]]))
+  (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps describe-mode]]))
 
 (defmethod get-initial-config :lang/latex []
   ["proton.lang.latex.use-latex-plus" false])
@@ -33,3 +33,5 @@
 (defmethod get-keymaps :lang/latex
   []
   [])
+
+(defmethod describe-mode :lang/latex [] {})

--- a/src/cljs/proton/layers/lang/python/core.cljs
+++ b/src/cljs/proton/layers/lang/python/core.cljs
@@ -1,5 +1,5 @@
 (ns proton.layers.lang.python.core
-  (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps]]))
+  (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps describe-mode]]))
 
 (defmethod init-layer! :lang/python
   [_ config]
@@ -20,3 +20,4 @@
 (defmethod get-keybindings :python [] (get-keybindings :lang/python))
 (defmethod get-initial-config :python [] (get-initial-config :lang/python))
 (defmethod init-layer! :python [] (init-layer! :lang/python))
+(defmethod describe-mode :lang/python [] {})

--- a/src/cljs/proton/layers/tools/git/core.cljs
+++ b/src/cljs/proton/layers/tools/git/core.cljs
@@ -1,5 +1,5 @@
 (ns proton.layers.tools.git.core
-  (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps]]))
+  (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps describe-mode]]))
 
 (defmethod init-layer! :tools/git
   [_ config]
@@ -35,3 +35,4 @@
 (defmethod get-keybindings :git [] (get-keybindings :tools/git))
 (defmethod get-initial-config :git [] (get-initial-config :tools/git))
 (defmethod init-layer! :git [] (init-layer! :tools/git))
+(defmethod describe-mode :git [] {})

--- a/src/cljs/proton/layers/tools/minimap/core.cljs
+++ b/src/cljs/proton/layers/tools/minimap/core.cljs
@@ -1,5 +1,5 @@
 (ns proton.layers.tools.minimap.core
-  (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps]]))
+  (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps describe-mode]]))
 
 (defmethod init-layer! :tools/minimap
   [_ config]
@@ -17,3 +17,4 @@
 
 (defmethod get-keymaps :tools/minimap [] [])
 (defmethod get-initial-config :tools/minimap [] [])
+(defmethod describe-mode :tools/minimap [] {})

--- a/src/cljs/proton/lib/atom.cljs
+++ b/src/cljs/proton/lib/atom.cljs
@@ -8,6 +8,7 @@
 (def keymaps (.-keymaps js/atom))
 (def views (.-views js/atom))
 (def config (.-config js/atom))
+(def grammars (.-grammars (.-grammars js/atom)))
 
 (def element (atom (generate-div "test" "proton-which-key")))
 (def bottom-panel (atom (.addBottomPanel workspace
@@ -115,3 +116,17 @@
   (let [binding-map (reduce deep-merge (map #(hash-map (get % 0) (get % 1)) bindings))
         selector-bound-map (hash-map selector binding-map)]
     (.add keymaps "custom-keymap" (clj->js selector-bound-map))))
+
+(defn get-active-editor []
+  (if-let [editor (.getActiveTextEditor workspace)]
+   (if-not (.isMini editor) editor nil)
+   nil))
+
+(defn find-grammar-by-name [name]
+ (first (filter #(= (.-name %) name) grammars)))
+
+(defn set-grammar [grammar]
+  (if-let [editor (get-active-editor)]
+    (if (string? grammar)
+     (.setGrammar editor (find-grammar-by-name grammar))
+     (.setGrammar editor grammar))))

--- a/src/cljs/proton/lib/mode.cljs
+++ b/src/cljs/proton/lib/mode.cljs
@@ -23,8 +23,8 @@
 
 (defn is-mode-activated? [editor] (get editor :active))
 
-(defn define-mode [name & options]
-  (swap! modes assoc-in [name] (apply hash-map options)))
+(defn define-mode [name options]
+  (swap! modes assoc-in [name] options))
 
 (defn define-keybindings [name keymap]
   (swap! modes assoc-in [name :mode-keybindings] keymap))

--- a/src/cljs/proton/lib/mode.cljs
+++ b/src/cljs/proton/lib/mode.cljs
@@ -9,6 +9,7 @@
 (defn- find-first [f coll] (first (filter f coll)))
 
 (defn editor-grammar [editor] (.-name (.getGrammar editor)))
+(defn editor-grammar-scope [editor] (.-scopeName (.getGrammar editor)))
 
 (defn file-extension [editor]
   "Returns file extenstion.
@@ -39,6 +40,11 @@
    (first filtered)
    nil))
 
+(defn find-mode-by-scope [scope]
+  (if-let [filtered (first (filter-modes-by-key-val :atom-scope scope))]
+   (first filtered)
+   nil))
+
 (defn mode-extensions-filter [ext]
   (fn [coll]
     (if-let [extensions (second coll)]
@@ -59,8 +65,9 @@
 
 (defn get-available-mode [editor]
    (let [by-grammar (find-mode-by-grammar (editor-grammar editor))
-         by-extension (find-mode-by-file-extension (file-extension editor))]
-    (or by-grammar by-extension)))
+         by-extension (find-mode-by-file-extension (file-extension editor))
+         by-scope (find-mode-by-scope (editor-grammar-scope editor))]
+    (or by-grammar by-extension by-scope)))
 
 (defn activate-mode [editor]
   (when-not (nil? editor)

--- a/src/cljs/proton/lib/mode.cljs
+++ b/src/cljs/proton/lib/mode.cljs
@@ -1,0 +1,74 @@
+(ns proton.lib.mode
+  (:require [cljs.nodejs :as nodejs]))
+
+(def path (nodejs/require "path"))
+
+(defonce modes (atom {}))
+(defonce editors (atom {}))
+
+(defn- find-first [f coll] (first (filter f coll)))
+
+(defn editor-grammar [editor] (.-name (.getGrammar editor)))
+
+(defn file-extension [editor]
+  "Returns file extenstion.
+  For dotfiles returns file name."
+  (if-let [file-path (.getPath editor)]
+   (let [parsed (.parse path (.getPath editor))
+         extension (.-ext parsed)]
+    (if (= extension "")
+        (.-base parsed)
+        extension))
+   ""))
+
+(defn is-mode-activated? [editor] (get editor :active))
+
+(defn define-mode [name & options]
+  (swap! modes assoc-in [name] (apply hash-map options)))
+
+(defn define-keybindings [name keymap]
+  (swap! modes assoc-in [name :mode-keybindings] keymap))
+
+(defn map-modes-with [key] (map #(vector (first %) (get-in (second %) [key])) (map identity @modes)))
+
+(defn filter-modes-by-key-val [key val]
+  (filter #(or (some #{val} (second %)) (= (second %) val)) (map-modes-with key)))
+
+(defn find-mode-by-grammar [grammar]
+  (if-let [filtered (first (filter-modes-by-key-val :atom-grammars grammar))]
+   (first filtered)
+   nil))
+
+(defn mode-extensions-filter [ext]
+  (fn [coll]
+    (if-let [extensions (second coll)]
+     (let [reg? (not (empty? (filter #(re-find % ext) (filter regexp? extensions))))
+           str? (not (nil? (some #{ext} (filter string? extensions))))]
+      (or reg? str?))
+     false)))
+
+(defn find-mode-by-file-extension [extension]
+  (if-let [filtered (first (filter (mode-extensions-filter extension) (map-modes-with :file-extensions)))]
+    (first filtered)
+    nil))
+
+(defn get-mode-keybindings [editor]
+  (if-let [mode-name (find-mode-by-grammar (editor-grammar editor))]
+    (get-in @modes [mode-name :mode-keybindings])
+    nil))
+
+(defn get-available-mode [editor]
+   (let [by-grammar (find-mode-by-grammar (editor-grammar editor))
+         by-extension (find-mode-by-file-extension (file-extension editor))]
+    (or by-grammar by-extension)))
+
+(defn activate-mode [editor]
+  (when-not (nil? editor)
+    (when-not (get @editors (.-id editor))
+      (if-let [mode (get-available-mode editor)]
+       (do
+          (swap! editors assoc (.-id editor) {:active true :mode mode})
+          (.onDidDestroy editor (fn []
+                                  (swap! editors dissoc (.-id editor))))
+          (if-let [init-fn (get-in @modes [mode :init])]
+             (init-fn)))))))

--- a/src/cljs/proton/lib/proton.cljs
+++ b/src/cljs/proton/lib/proton.cljs
@@ -1,7 +1,9 @@
 (ns proton.lib.proton
   (:require [cljs.reader :as reader]
             [cljs.nodejs :as node]
+            [proton.lib.mode :as mode-manager]
             [proton.lib.helpers :as helpers]
+            [proton.lib.atom :as atom-env]
             [proton.layers.base :as layerbase]))
 
 (def config-path (str (.. js/process -env -HOME) "/.proton"))
@@ -37,3 +39,10 @@
 
 (defn init-layers! [layers config]
   (doall (map #(layerbase/init-layer! (keyword %) config) layers)))
+
+(defn- on-active-pane-item [item]
+  (if-let [editor (atom-env/get-active-editor)]
+    (when (= (.-id editor) (.-id item))
+     (mode-manager/activate-mode editor))))
+
+(defn panel-item-subscription [] (.onDidChangeActivePaneItem atom-env/workspace on-active-pane-item))

--- a/src/cljs/proton/lib/proton.cljs
+++ b/src/cljs/proton/lib/proton.cljs
@@ -40,6 +40,11 @@
 (defn init-layers! [layers config]
   (doall (map #(layerbase/init-layer! (keyword %) config) layers)))
 
+(defn init-modes-for-layers [layers]
+  (doall
+    (map #(mode-manager/define-mode (get % :mode-name) (dissoc % :mode-name))
+     (filter #(not (nil? (get % :mode-name))) (map #(layerbase/describe-mode %) layers)))))
+
 (defn- on-active-pane-item [item]
   (if-let [editor (atom-env/get-active-editor)]
     (when (= (.-id editor) (.-id item))


### PR DESCRIPTION
Implemented basic **mode** functionality.
Added function to define mode with extra info.
Prefer to use inside `init-layer!` function, for example:
```clojure
;; src/proton/layers/clojure
(defmethod init-layer! :clojure
  [_ config]
  ;; define mode name
  (mode/define-mode :clojure 
     ;; initialize for selected editor grammar
     :atom-grammars ["Clojure"] 
     ;; or initialize for file extension
     :file-extensions [#"\.proton$"]
     ;; custom init function on mode activation
     :init (fn []
            (atom-env/set-grammar "Clojure")))
  ;; define mode keybindings
  ;; also able to define within define-mode function using :mode-keybindings keyword
  ;; this one 
  (mode/define-keybindings :clojure
    {:t {:category "toggles"
         :p {:action "parinfer:toggleMode" :title "Toggle Parinfer Mode"}}})
   ;; same as
   (mode/define-mode :clojure
      :mode-keybindings {:p {:category "my-category"}})
```
Mode actions available via <kbd>SPC m</kbd>.
@dvcrn can you please review? Thanks.