### PR TITLE
added advanced new file and f keymap category

### DIFF
--- a/src/cljs/proton/layers/core/keybindings.cljs
+++ b/src/cljs/proton/layers/core/keybindings.cljs
@@ -19,6 +19,19 @@
               :title "focus left pane"}
           :tab {:action "tab-switcher:next"
                 :title "previous buffer"}
+          :f {:category "files"
+               :e {:category "editor(atom)"
+                   :d {:title "find-dotfile"
+                       :fx (fn []
+                             (.open (.-workspace js/atom) proton/config-path))}
+                   :s {:title "find-stylesheet"
+                       :action "application:open-your-stylesheet"}
+                   :i {:title "find-init script"
+                       :action "application:open-your-init-script"}
+                   :p {:title "find-snippets"
+                       :action "application:open-your-snippets"}}
+               :f {:title "advanced-open-file"
+                   :action "advanced-open-file:toggle"}}
           :w {:category "window"
               :d {:action "pane:close"
                   :target actions/get-active-pane

--- a/src/cljs/proton/layers/core/packages.cljs
+++ b/src/cljs/proton/layers/core/packages.cljs
@@ -14,6 +14,9 @@
      :hyperclick
      :nuclide-file-watcher
 
+     ;; other
+     :advanced-open-file
+
      ;; current default theme
      :atom-material-ui
      :atom-material-syntax


### PR DESCRIPTION
This kinda goes along with the theme of #23 as well as the concept of matching spacemacs more

The `spc f e` category is in the flavor of spacemacs (`spc f e d` opens `~/.proton` in atom but `~/.spacemacs` in emacs). We already have some some things like this in the meta category (`spc _`) so we'd have to consider if we want to follow their path or make our own.

However, I really like `advanced-open-file` and think it is a great fit for `spc f f` (that is the part of this PR that addresses #23)