### PR TITLE
Fix mode keybindings are empty.

### DIFF
--- a/src/cljs/proton/lib/mode.cljs
+++ b/src/cljs/proton/lib/mode.cljs
@@ -59,9 +59,10 @@
     nil))
 
 (defn get-mode-keybindings [editor]
-  (if-let [mode-name (find-mode-by-grammar (editor-grammar editor))]
-    (get-in @modes [mode-name :mode-keybindings])
-    nil))
+  (when-not (nil? editor)
+    (if-let [mode-name (get-in @editors [(.-id editor) :mode])]
+      (get-in @modes [mode-name :mode-keybindings])
+      nil)))
 
 (defn get-available-mode [editor]
    (let [by-grammar (find-mode-by-grammar (editor-grammar editor))


### PR DESCRIPTION
Get mode keybindings by editor id instead of grammar.