### PR TITLE
Added new packages and keybindings for git layer.

### DIFF
--- a/src/cljs/proton/layers/tools/git/README.md
+++ b/src/cljs/proton/layers/tools/git/README.md
@@ -2,6 +2,50 @@
 
 This layer adds git keybindings powered by git-plus and introduces the git category under `<spc> g`.
 
+Includes following atom packages:
+
+- [git-plus](https://atom.io/packages/git-plus)
+- [language-diff](https://atom.io/packages/language-diff)
+- [atomatigit](https://atom.io/packages/atomatigit)
+- [blame](https://atom.io/packages/blame)
+- [merge-conflicts](https://atom.io/packages/merge-conflicts)
+- [git-history](https://atom.io/packages/git-history)
+
 ### Install
 
-Add `:lang/git` to your layers.
+Add `:tools/git` to your layers.
+
+### Key Bindings
+
+Key Binding | Description
+------------|----------------------------------
+`SPC g a`   | Git Add Files
+`SPC g S`   | Git Status
+`SPC g s`   | Atomatigit Git Status
+`SPC g P`   | Git Push
+`SPC g c`   | Git Commit
+`SPC g b`   | Toggle Git Blame
+`SPC g L`   | Git Log
+`SPC g l`   | Git Log for Current File
+`SPC g h`   | Git History for Current File
+`SPC g d n` | Git Diff Next Hunk
+`SPC g d N` | Git Diff Previous Hunk
+`SPC g d l` | Toggle Diff List for Current File
+
+### Configuration
+
+Name                             | Default                  | Type        | Description
+---------------------------------|--------------------------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------
+`git-plus.includeStagedDiff`     | true                     | __boolean__ | Include staged diffs?
+`git-plus.openInPane`            | true                     | __boolean__ | Allow commands to open new panes
+`git-plus.splitPane`             | 'right'                  | __string__  | Where should new panes go? (Defaults to right)
+`git-plus.wordDiff`              | true                     | __boolean__ | Should word diffs be highlighted in diffs?
+`git-plus.amountOfCommitsToShow` | 25                       | __integer__ | Amount Of Commits To Show
+`git-plus.gitPath`               | 'git'                    | __string__  | Where is your git?
+`git-plus.messageTimeout`        | 5                        | __integer__ | How long should success/error messages be shown?
+`merge-conflicts.gitPath`        | ''                       | __string__  | Absolute path to your git executable.
+`blame.gutterFormat`             | '{hash} {date} {author}' | __string__  | Placeholders: `{hash}`, `{date}` and `{author}.`
+`blame.dateFormat`               | YYYY-MM-DD               | __string__  | Placeholders: `YYYY` (year), `MM` (month), `DD` (day), `HH` (hours), `mm` (minutes).See [momentjs documentation](http://momentjs.com/docs/) for more information.
+`blame.defaultWith`              | 250                      | __integer__ | Default width (px)
+`git-history.showDiff`           | false                    | __boolean__ | Show diff for selected item
+`git-history.maxCommits`         | 100                      | __integer__ | Maximum visible items

--- a/src/cljs/proton/layers/tools/git/core.cljs
+++ b/src/cljs/proton/layers/tools/git/core.cljs
@@ -1,4 +1,5 @@
 (ns proton.layers.tools.git.core
+  (:require [proton.layers.core.actions :as actions :refer [state]])
   (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps describe-mode]]))
 
 (defmethod init-layer! :tools/git
@@ -7,27 +8,31 @@
 
 (defmethod describe-mode :tools/git [] {})
 
-(defn get-active-editor [atom]
-  (.getView (.-views atom) (.getActiveTextEditor (.-workspace atom))))
-
 (defmethod get-keybindings :tools/git
   []
   {:g {:category "git"
        :a {:action "git-plus:add" :title "add files"}
        :S {:action "git-plus:status" :title "git-plus status"}
-       :s {:action "atomatigit:toggle" :title "status" :target get-active-editor}
+       :s {:action "atomatigit:toggle" :title "status" :target actions/get-active-editor}
        :P {:action "git-plus:push" :title "push"}
        :c {:action "git-plus:commit" :title "commit"}
+       :b {:action "blame:toggle" :title "blame" :target actions/get-active-editor}
+       :L {:action "git-plus:log-current-file" :target actions/get-active-editor :title "log current file"}
+       :l {:action "git-plus:log" :title "log project"}
+       :h {:action "git-history:show-file-history" :target actions/get-active-editor :title "file history"}
        :d {:category "git diff"
-           :n {:action "git-diff:move-to-next-diff" :target get-active-editor :title "next diff"}
-           :N {:action "git-diff:move-to-previous-diff" :target get-active-editor :title "previous diff"}
-           :l {:action "git-diff:toggle-diff-list" :target get-active-editor :title "list diffs"}}}})
+           :n {:action "git-diff:move-to-next-diff" :target actions/get-active-editor :title "next diff"}
+           :N {:action "git-diff:move-to-previous-diff" :target actions/get-active-editor :title "previous diff"}
+           :l {:action "git-diff:toggle-diff-list" :target actions/get-active-editor :title "list diffs"}}}})
 
 (defmethod get-packages :tools/git
   []
   [:git-plus
    :language-diff
-   :atomatigit])
+   :atomatigit
+   :blame
+   :merge-conflicts
+   :git-history])
 
 (defmethod get-keymaps :tools/git []
   [{:selector ".atomatigit .file-list-view" :keymap [["s" "atomatigit:stage"]


### PR DESCRIPTION
Added packages:
 - blame
 - git-history
 - merge-conflicts

Added keybindgs:
 - `SPC g b` - toggle blame
 - `SPC g l` - git log
 - `SPC g L` - git log for current file
 - `SPC g h` - git history for current file

Little refactor. Use get-active-editor from proton.layers.core.actions.

Updated Readme. Added Key Bindings and Configuration sections.