### PR TITLE
Concatenate configs from layers.

### DIFF
--- a/src/cljs/proton/layers/lang/latex/core.cljs
+++ b/src/cljs/proton/layers/lang/latex/core.cljs
@@ -2,7 +2,7 @@
   (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps describe-mode]]))
 
 (defmethod get-initial-config :lang/latex []
-  ["proton.lang.latex.use-latex-plus" false])
+  [["proton.lang.latex.use-latex-plus" false]])
 
 ; Define default packages
 (def packages

--- a/src/cljs/proton/lib/proton.cljs
+++ b/src/cljs/proton/lib/proton.cljs
@@ -32,7 +32,7 @@
   (reduce helpers/deep-merge (map #(layerbase/get-keybindings (keyword %)) layers)))
 
 (defn configs-for-layers [layers]
-  (reduce conj (filter #(not (empty? %)) (map #(layerbase/get-initial-config (keyword %)) layers))))
+  (reduce concat (filter #(not (empty? %)) (map #(layerbase/get-initial-config (keyword %)) layers))))
 
 (defn keymaps-for-layers [layers]
   (reduce concat (map #(layerbase/get-keymaps (keyword %)) layers)))


### PR DESCRIPTION
Error thrown when returned value from `(defmethod get-initial-config)` is vector of vectors.