### PR TITLE
Allow pass selector as :target to keybinding.

### DIFF
--- a/src/cljs/proton/lib/atom.cljs
+++ b/src/cljs/proton/lib/atom.cljs
@@ -71,8 +71,9 @@
   (println "evalling")
   (let [action (get-in tree (conj sequence :action))
         target (get-in tree (conj sequence :target))
+        selector (when (string? target) (js/document.querySelector target))
         fx (get-in tree (conj sequence :fx))
-        dom-target (if (nil? target) (.getView views workspace) (target js/atom))]
+        dom-target (if (nil? target) (.getView views workspace) (or selector (target js/atom)))]
 
     ;; functions always go first
     (if (not (nil? fx))


### PR DESCRIPTION
This will allow to pass string selector using `:target` for keybinding. For example:

```clj
  { :g { 
         :d {
              :t { :action "git-diff-details:toggle-git-diff-details" :target "atom-text-editor.is-focused"}}}}
```