### PR TITLE
Theme tweaks

### DIFF
--- a/src/cljs/proton/layers/core/core.cljs
+++ b/src/cljs/proton/layers/core/core.cljs
@@ -29,8 +29,15 @@
    ["vim-mode-plus.flashOnUndoRedo" true]
    ["vim-mode-plus.useClipboardAsDefaultRegister" true]
 
-
+   ;; ui
    ["core.themes" ["atom-material-ui" "atom-material-syntax"]]
+   ["atom-material-ui.ui.accentColor" "Cyan"]
+   ["atom-material-ui.tabs.tabSize" "Small"]
+   ["atom-material-ui.tabs.rippleAccentColor" true]
+   ["atom-material-ui.tabs.showTabIcons" "Show on active tab"]
+   ["atom-material-ui.treeView.compactTreeView" true]
+   ["atom-material-ui.panels.panelContrast" true]
+
    ["editor.softWrap" true]
    ["editor.fontFamily" "Hack"]])
 


### PR DESCRIPTION
Another change for https://github.com/dvcrn/proton/issues/23

Material is way too big by default. I tweaked it a bit to make a more solid default:

![screen shot 2015-12-18 at 3 11 16 pm](https://cloud.githubusercontent.com/assets/688326/11890720/cb757e3c-a59a-11e5-96ad-45ea3284762a.png)

changes to

![screen shot 2015-12-18 at 3 15 27 pm](https://cloud.githubusercontent.com/assets/688326/11890719/cb6f82d4-a59a-11e5-943f-27b53265c5f0.png)

Changes:

* Smaller tabs
* Smaller file-tree
* More colorful accent color
* Icon on active tab
* Slight contrast for panels