### PR TITLE
update latex config

### DIFF
--- a/src/cljs/proton/layers/lang/latex/README.md
+++ b/src/cljs/proton/layers/lang/latex/README.md
@@ -20,6 +20,6 @@ Add `:lang/latex` to your layers.
 
 ### Configuration
 
-Name                               | Default | Type        | Description
------------------------------------|---------|-------------|-----------------------------
-`proton.lang.latex.use-latex-plus` | false   | __boolean__ | use latex-plus for `latexmk`
+| Name                            | Default | Type        | Description                                                         |
+|---------------------------------|---------|-------------|---------------------------------------------------------------------|
+| `proton.latex.latexmk-provider` | :latex  | __keyword__ | which latex provider to pick? Options are `:latex` or `:latex-plus` |

--- a/src/cljs/proton/layers/lang/latex/core.cljs
+++ b/src/cljs/proton/layers/lang/latex/core.cljs
@@ -1,37 +1,23 @@
 (ns proton.layers.lang.latex.core
+  (:require [proton.lib.helpers :as helpers])
   (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps describe-mode]]))
 
+(def layer-state (atom {}))
+
 (defmethod get-initial-config :lang/latex []
-  [["proton.lang.latex.use-latex-plus" false]])
+  [["proton.latex.latexmk-provider" :latex]])
 
-; Define default packages
-(def packages
-  (atom
-    [:latexer
-     :language-latex
-     :autocomplete-bibtex
-     :pdf-view]))
-
-(defmethod init-layer! :lang/latex [_ config]
+(defmethod init-layer! :lang/latex
+  [_ config]
+  (println "init latex")
   (let [config-map (into (hash-map) config)]
-    (if (config-map "proton.lang.latex.use-latex-plus")
-      (do
-        (swap! packages #(into [] (concat % [:latex-plus]))))
-      (do
-        (swap! packages #(into [] (concat % [:latex])))))
-    (println packages)))
-
-
-(defmethod get-keybindings :lang/latex
-  []
-  {})
+    (swap! layer-state assoc :provider (config-map "proton.latex.latexmk-provider"))))
 
 (defmethod get-packages :lang/latex []
-  @packages)
+  (case (@layer-state :provider)
+    :latex [:latexer :language-latex :autocomplete-bibtex :pdf-view :latex]
+    :latex-plus [:latexer :language-latex :autocomplete-bibtex :pdf-view :latex-plus]))
 
-
-(defmethod get-keymaps :lang/latex
-  []
-  [])
-
+(defmethod get-keybindings :lang/latex [] {})
+(defmethod get-keymaps :lang/latex [] [])
 (defmethod describe-mode :lang/latex [] {})


### PR DESCRIPTION
handle latex config in a cleaner way.

Before we were `concat`ing onto an atom each time the config was parsed. Now we just set the value of an atom with the info from the config value.