### PR TITLE
added config for timout after init

### DIFF
--- a/src/cljs/proton/core.cljs
+++ b/src/cljs/proton/core.cljs
@@ -157,7 +157,8 @@
           (atom-env/insert-process-step! "All done!" "")
           (proton/init-modes-for-layers all-layers)
           (mode-manager/activate-mode (atom-env/get-active-editor))
-          (.setTimeout js/window #(atom-env/hide-modal-panel) 3000))))))
+          (let [config-map (into (hash-map) all-configuration)]
+            (.setTimeout js/window #(atom-env/hide-modal-panel) (config-map "proton.core.post-init-timeout"))))))))
 
 (defn on-space []
   (reset! current-chain [])

--- a/src/cljs/proton/layers/core/core.cljs
+++ b/src/cljs/proton/layers/core/core.cljs
@@ -23,6 +23,7 @@
   [["proton.core.showTabBar" false]
    ["proton.core.relativeLineNumbers" false]
    ["proton.core.quickOpenProvider" :normal]
+   ["proton.core.post-init-timeout" 3000]
    ;; vim-mode
    ["vim-mode-plus.useSmartcaseForSearch" true]
    ["vim-mode-plus.incrementalSearch" true]


### PR DESCRIPTION
After init we have a 3 second timeout before closing the modal window. 

This PR lets the user set the duration of that time out using the config variable `proton.core.post-init-timeout`

I don't love the name and it should probably be documented somewhere, but it works for me!