### PR TITLE
Skip force activation for themes.

### DIFF
--- a/src/cljs/proton/core.cljs
+++ b/src/cljs/proton/core.cljs
@@ -155,7 +155,7 @@
                 (atom-env/mark-last-step-as-completed!))))
 
           ;; Make sure all collected packages are definitely enabled
-          (doall (map #(pm/enable-package %) layer-packages))
+          (doall (map #(pm/enable-package %) (filter pm/is-package? layer-packages)))
 
           (atom-env/insert-process-step! "All done!" "")
           (proton/init-modes-for-layers all-layers)

--- a/src/cljs/proton/lib/package_manager.cljs
+++ b/src/cljs/proton/lib/package_manager.cljs
@@ -20,6 +20,12 @@
   (let [pkgs (get-all-packages)]
     (not (= -1 (.indexOf pkgs package-name)))))
 
+(defn is-theme? [package-name]
+  (.isTheme (.getLoadedPackage packages (name package-name))))
+
+(defn is-package? [package-name]
+  ((comp not is-theme?) package-name))
+
 (defn get-to-remove [all-packages]
   (let [pkgs (set all-packages)]
     (filter #(if (not (contains? pkgs %)) %) (into [] (map keyword (get-all-packages))))))


### PR DESCRIPTION
Force activated themes cause mess with `core.themes` config.
In my `.proton` I have few themes `:additional-packages` *dracula-ui*, *dracula-theme*, *slime* and appropriate config `["core.themes" ["dracula-ui" "dracula-theme"]]`.  When proton activates themes `core.themes` config become:
```js
atom.config.get('core.themes')
["slime", "dracula-theme", "dracula-ui", "atom-material-syntax", "atom-material-ui", "dracula-ui", "dracula-theme"]
```