### PR TITLE
Added proto-repl package, mode improvements.

### DIFF
--- a/src/cljs/proton/core.cljs
+++ b/src/cljs/proton/core.cljs
@@ -131,10 +131,6 @@
           ;; set the user config
           (atom-env/insert-process-step! "Applying user configuration")
           (doall (map #(atom-env/set-config! (get % 0) (get % 1)) all-configuration))
-          (let [core-themes (string/join " " (config-map "core.themes"))
-                theme-switch-profiles (config-map "theme-switch.profiles")]
-            (when (nil? (some #{core-themes} theme-switch-profiles))
-              (atom-env/set-config! "theme-switch.profiles" (concat [core-themes] theme-switch-profiles))))
           (atom-env/mark-last-step-as-completed!)
 
           ;; Make sure all collected packages are definitely enabled

--- a/src/cljs/proton/layers/base.cljs
+++ b/src/cljs/proton/layers/base.cljs
@@ -11,6 +11,7 @@
 (defmulti get-keybindings dispatch)
 (defmulti get-keymaps dispatch)
 (defmulti describe-mode dispatch)
+(defmulti init-package identity)
 
 (defn register-layer-dependencies [key deps]
   (let [layer-deps @layer-dependencies]
@@ -44,3 +45,5 @@
 (defmethod describe-mode :default [key]
   (helpers/console! (gen-error "describe-mode") key)
   {})
+
+(defmethod init-package :default [] [] [])

--- a/src/cljs/proton/layers/core/core.cljs
+++ b/src/cljs/proton/layers/core/core.cljs
@@ -1,10 +1,12 @@
 (ns proton.layers.core.core
-  (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps describe-mode]])
+  (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps describe-mode init-package]])
   (:require [proton.lib.proton :as proton]
             [proton.lib.package_manager :as package]
+            [clojure.string :as string :refer [join]]
             [proton.layers.core.keybindings :refer [keybindings]]
             [proton.layers.core.actions :as actions :refer [state]]
             [proton.layers.core.packages :refer [packages]]
+            [proton.lib.atom :as atom-env :refer [get-config set-config!]]
             [cljs.nodejs :as node]))
 
 (def keymaps (atom
@@ -45,7 +47,7 @@
 
    ["editor.softWrap" true]
    ["editor.fontFamily" "Hack"]
-   ["theme-switch.profiles" ["atom-material-ui" "atom-material-syntax"
+   ["theme-switch.profiles" ["atom-material-ui atom-material-syntax"
                              "atom-dark-ui atom-dark-syntax"
                              "atom-light-ui atom-light-syntax"
                              "one-dark-ui one-dark-syntax"
@@ -79,6 +81,12 @@
         (swap! keybindings assoc-in [:b :b :action] "nuclide-open-filenames-provider:toggle-provider")
         (swap! keybindings assoc-in [:p :f :action] "nuclide-fuzzy-filename-provider:toggle-provider")
         (swap! keybindings assoc-in [:p :r :action] "nuclide-recent-files-provider:toggle-provider")))))
+
+(defmethod init-package [:core :theme-switch] []
+  (let [core-themes (string/join " " (atom-env/get-config "core.themes"))
+        theme-switch-profiles (array-seq (atom-env/get-config "theme-switch.profiles"))]
+    (when (nil? (some #{core-themes} theme-switch-profiles))
+      (atom-env/set-config! "theme-switch.profiles" (concat [core-themes] theme-switch-profiles)))))
 
 (defmethod get-keybindings :core [] @keybindings)
 (defmethod get-keymaps :core [] @keymaps)

--- a/src/cljs/proton/layers/lang/clojure/core.cljs
+++ b/src/cljs/proton/layers/lang/clojure/core.cljs
@@ -1,8 +1,9 @@
 (ns proton.layers.lang.clojure.core
-  (:require [proton.lib.mode :as mode :refer [define-mode define-keybindings]]
+  (:require [proton.lib.mode :as mode :refer [define-mode]]
             [proton.lib.atom :as atom-env :refer [set-grammar]]
             [proton.lib.helpers :as helpers])
-  (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps describe-mode register-layer-dependencies]]))
+  (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps describe-mode register-layer-dependencies init-package]]
+        [proton.lib.keymap :only [set-proton-keys-for-mode]]))
 
 (defn- clojure-mode-init []
  (atom-env/set-grammar "Clojure"))
@@ -12,16 +13,49 @@
   (helpers/console! "init" :lang/clojure)
   (register-layer-dependencies :tools/linter [:linter-clojure]))
 
+(defmethod init-package [:lang/clojure :Parinfer] []
+  (helpers/console! "init Parinfer package" :lang/clojure)
+  (mode/define-package-mode :Parinfer
+    {:mode-keybindings
+     {:T {:category "toggles"
+          :p {:action "parinfer:toggleMode" :title "Toggle Parinfer Mode"}}}})
+  (mode/link-modes :clojure-lang-mode (mode/package-mode-name :Parinfer)))
+
+(defmethod init-package [:lang/clojure :proto-repl] []
+  (helpers/console! "init proto-repl package" :lang/clojure)
+  (mode/define-package-mode :proto-repl
+    {:mode-keybindings
+      {:e {:category "eval"
+           :r {:action "proto-repl:execute-selected-text" :title "selected text"}
+           :b {:action "proto-repl:execute-block" :title "block"}
+           :B {:action "proto-repl:execute-top-block" :title "top block"}}
+       :h {:category "help/docs"
+           :d {:action "proto-repl:print-var-documentation" :title "var doc"}
+           :c {:action "proto-repl:print-var-code" :title "print var code"}
+           :s {:action "proto-repl:open-file-containing-var" :title "print var/ns code"}}
+       :s {:category "repl"
+           :b {:action "proto-repl:load-current-file" :title "load current file"}
+           :c {:action "proto-repl:clear-repl" :title "clear"}
+           :i {:action "proto-repl:toggle" :title "start"}
+           :ctrl-c {:action "proto-repl:interrupt" :title "interrupt"}
+           :p {:action "proto-repl:pretty-print" :title "pretty print"}
+           :q {:action "proto-repl:exit-repl" :title "quit"}
+           :x {:action "proto-repl:refresh-namespaces" :title "refresh"}
+           :X {:action "proto-repl:super-refresh-namespaces" :title "super refresh"}}
+       :t {:category "tests"
+           :a {:action "proto-repl:run-all-tests" :title "run all"}
+           :t {:action "proto-repl:run-selected-test" :title "run selected"}
+           :c {:action "proto-repl:run-tests-in-namespace" :title "run in ns"}}}})
+  (mode/link-modes :clojure-lang-mode (mode/package-mode-name :proto-repl)))
+
 (defmethod get-packages :lang/clojure []
-  [:Parinfer])
+  [:Parinfer
+   :proto-repl])
 
 (defmethod describe-mode :lang/clojure []
-  {:mode-name :clojure
+  {:mode-name :clojure-lang-mode
    :atom-grammars ["Clojure"]
-   :file-extensions [#"\.proton$"]
-   :mode-keybindings
-   {:t {:category "toggles"
-        :p {:action "parinfer:toggleMode" :title "Toggle Parinfer Mode"}}}
+   :file-extensions [#"proton$"]
    :init clojure-mode-init})
 
 

--- a/src/cljs/proton/layers/lang/clojure/core.cljs
+++ b/src/cljs/proton/layers/lang/clojure/core.cljs
@@ -19,7 +19,7 @@
     {:mode-keybindings
      {:T {:category "toggles"
           :p {:action "parinfer:toggleMode" :title "Toggle Parinfer Mode"}}}})
-  (mode/link-modes :clojure-lang-mode (mode/package-mode-name :Parinfer)))
+  (mode/link-modes :clojure-major-mode (mode/package-mode-name :Parinfer)))
 
 (defmethod init-package [:lang/clojure :proto-repl] []
   (helpers/console! "init proto-repl package" :lang/clojure)
@@ -46,14 +46,14 @@
            :a {:action "proto-repl:run-all-tests" :title "run all"}
            :t {:action "proto-repl:run-selected-test" :title "run selected"}
            :c {:action "proto-repl:run-tests-in-namespace" :title "run in ns"}}}})
-  (mode/link-modes :clojure-lang-mode (mode/package-mode-name :proto-repl)))
+  (mode/link-modes :clojure-major-mode (mode/package-mode-name :proto-repl)))
 
 (defmethod get-packages :lang/clojure []
   [:Parinfer
    :proto-repl])
 
 (defmethod describe-mode :lang/clojure []
-  {:mode-name :clojure-lang-mode
+  {:mode-name :clojure-major-mode
    :atom-grammars ["Clojure"]
    :file-extensions [#"proton$"]
    :init clojure-mode-init})

--- a/src/cljs/proton/layers/lang/julia/core.cljs
+++ b/src/cljs/proton/layers/lang/julia/core.cljs
@@ -1,7 +1,8 @@
 (ns proton.layers.lang.julia.core
   (:require [proton.layers.core.actions :as actions :refer [state]]
-            [proton.lib.helpers :as helpers])
-  (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps describe-mode]]))
+            [proton.lib.helpers :as helpers]
+            [proton.lib.mode :as mode])
+  (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps describe-mode init-package]]))
 
 (defmethod get-initial-config :lang/julia
   []
@@ -18,59 +19,65 @@
    :julia-client
    :ink])
 
+(defmethod init-package [:lang/julia :julia-client] []
+  (helpers/console! "init julia-client package" :lang/julia)
+  (mode/define-package-mode :julia-client
+    {:mode-keybindings
+      {:r {:action "julia-client:open-a-repl"
+           :title "Open a REPL"}
+       :s {:action "julia-client:start-julia"
+           :title "Start Julia"}
+       :m {:action "julia-client:set-working-module"
+           :target actions/get-active-editor
+           :title "Set working module"}
+       :d {:action "julia:open-startup-file"
+           :title "Open juliarc"}
+       :R {:action "julia-client:start-repl-client"
+           :title "Start REPL client"}
+       :f {:category "Choose folder"
+                :f {:action "julia-client:work-in-file-folder"
+                    :target actions/get-active-editor
+                    :title "File"}
+                :h {:action "julia-client:work-in-home-folder"
+                    :title "Home"}
+                :p {:action "julia-client:work-in-project-folder"
+                    :target actions/get-active-editor
+                    :title "Project"}}
+       :c {:category "clear"
+             :c {:action "julia-client:clear-console"
+                 :title "Console"}
+             :i {:action "inline-results:clear-all"
+                 :target actions/get-active-editor
+                 :title "Inline"}}
+       :e {:category "evaluate"
+             :b {:action "julia-client:evaluate"
+                 :target actions/get-active-editor
+                 :title "Block"}
+             :a {:action "julia-client:evaluate-all"
+                 :target actions/get-active-editor
+                 :title "All"}}
+       :t {:category "toggles"
+             :c {:action "julia-client:toggle-console"
+                 :title "console"}
+             :l {:action "julia-client:reset-loading-indicator"
+                 :title "Loading indicator"}
+             :d {:action "julia-client:toggle-documentation"
+                 :target actions/get-active-editor
+                 :title "Documentation"}
+             :m {:action "julia-client:toggle-methods"
+                 :target actions/get-active-editor
+                 :title "Methods"}}
+       :l {:action "julia-client:reset-loading-indicator"
+           :title "Reset indicator"}
+       :k {:action "julia-client:kill-julia"
+           :title "Kill Julia"}}})
+  (mode/link-modes :julia-major-mode (mode/package-mode-name :julia-client)))
+
+
 (defmethod describe-mode :lang/julia
  []
- {:mode-name :julia
-  :atom-scope ["source.julia"]
-  :mode-keybindings
-    {:r {:action "julia-client:open-a-repl"
-         :title "Open a REPL"}
-     :s {:action "julia-client:start-julia"
-         :title "Start Julia"}
-     :m {:action "julia-client:set-working-module"
-         :target actions/get-active-editor
-         :title "Set working module"}
-     :d {:action "julia:open-startup-file"
-         :title "Open juliarc"}
-     :R {:action "julia-client:start-repl-client"
-         :title "Start REPL client"}
-     :f {:category "Choose folder"
-              :f {:action "julia-client:work-in-file-folder"
-                  :target actions/get-active-editor
-                  :title "File"}
-              :h {:action "julia-client:work-in-home-folder"
-                  :title "Home"}
-              :p {:action "julia-client:work-in-project-folder"
-                  :target actions/get-active-editor
-                  :title "Project"}}
-     :c {:category "clear"
-           :c {:action "julia-client:clear-console"
-               :title "Console"}
-           :i {:action "inline-results:clear-all"
-               :target actions/get-active-editor
-               :title "Inline"}}
-     :e {:category "evaluate"
-           :b {:action "julia-client:evaluate"
-               :target actions/get-active-editor
-               :title "Block"}
-           :a {:action "julia-client:evaluate-all"
-               :target actions/get-active-editor
-               :title "All"}}
-     :t {:category "toggles"
-           :c {:action "julia-client:toggle-console"
-               :title "console"}
-           :l {:action "julia-client:reset-loading-indicator"
-               :title "Loading indicator"}
-           :d {:action "julia-client:toggle-documentation"
-               :target actions/get-active-editor
-               :title "Documentation"}
-           :m {:action "julia-client:toggle-methods"
-               :target actions/get-active-editor
-               :title "Methods"}}
-     :l {:action "julia-client:reset-loading-indicator"
-         :title "Reset indicator"}
-     :k {:action "julia-client:kill-julia"
-         :title "Kill Julia"}}})
+ {:mode-name :julia-major-mode
+  :atom-scope ["source.julia"]})
 
 (defmethod get-keymaps :lang/julia [] [])
 (defmethod get-keybindings :lang/julia [] {})

--- a/src/cljs/proton/lib/atom.cljs
+++ b/src/cljs/proton/lib/atom.cljs
@@ -3,6 +3,15 @@
             [cljs.nodejs :as node]
             [clojure.string :as string :refer [lower-case upper-case]]))
 
+;; reference to atom shell API
+(def ashell (node/require "atom"))
+
+;; get atom.CompositeDisposable so we can work with it
+(def composite-disposable (.-CompositeDisposable ashell))
+
+;; Initialise new composite-disposable so we can add stuff to it later
+(def subscriptions (new composite-disposable))
+
 (def commands (.-commands js/atom))
 (def workspace (.-workspace js/atom))
 (def keymaps (.-keymaps js/atom))
@@ -174,7 +183,7 @@
 (defn get-package [package-name]
   (.getLoadedPackage packages package-name))
 
-(defn is-installed? [package-name]
+(defn is-package-installed? [package-name]
   (if (.isPackageLoaded packages package-name)
     true
     (let [pkgs (get-all-packages)]

--- a/src/cljs/proton/lib/keymap.cljs
+++ b/src/cljs/proton/lib/keymap.cljs
@@ -1,23 +1,25 @@
 (ns proton.lib.keymap
   #_(:require [proton.core]
               [proton.lib.mode])
-  (:require [proton.lib.atom :as atom-env :refer [workspace commands views eval-action!]]))
+  (:require [proton.lib.atom :as atom-env :refer [workspace commands views eval-action!]]
+            [proton.lib.helpers :as helpers :refer [deep-merge]]))
 
 (defonce atom-keymap (atom {}))
 (defonce proton-keymap (atom {}))
 (defonce mode-keymap (atom {}))
 
 (def get-current-editor-mode #(proton.lib.mode.get-current-editor-mode))
+(defn get-mode-info [mode-name] (proton.lib.mode.get-mode mode-name))
 
 (defn set-proton-keys-for-mode
   "Define multiple key bindings associated with mode."
   [mode-name keybindings-map]
-  (swap! mode-keymap merge (assoc {} mode-name keybindings-map)))
+  (swap! mode-keymap helpers/deep-merge (assoc {} mode-name keybindings-map)))
 
 (defn set-proton-leader-keys
   "Define multiple key bindings with associated action for `proton-keymap`."
   [keybindings-map]
-  (swap! proton-keymap merge keybindings-map))
+  (swap! proton-keymap helpers/deep-merge keybindings-map))
 
 (defn- is-exec? [hash]
   (let [{:keys [action target fx title]} hash]
@@ -29,7 +31,13 @@
   (reset! mode-keymap {}))
 
 (defn get-mode-keybindings [mode-name]
-  (get @mode-keymap (keyword mode-name)))
+  (when-not (nil? mode-name)
+    (if-let [mode-info (get-mode-info mode-name)]
+      (let [mode-map (or (get @mode-keymap (keyword mode-name)) {})
+            child-modes (mode-info :child)]
+        (if-not (nil? child-modes)
+          (helpers/deep-merge (reduce #(helpers/deep-merge %1 (get-mode-keybindings %2)) {} child-modes) mode-map)
+          mode-map)))))
 
 (defn find-keybindings [ks]
   (let [current-mode (get-current-editor-mode)
@@ -43,3 +51,6 @@
 
 (defn is-action? [{:keys [fx action]}]
   (not (nil? (or fx action))))
+
+(defn unset-keymap-for-mode! [mode-name]
+  (swap! mode-keymap dissoc mode-name))

--- a/src/cljs/proton/lib/package_manager.cljs
+++ b/src/cljs/proton/lib/package_manager.cljs
@@ -119,12 +119,12 @@
 
 (defn on-package-deactivated [package]
   (let [package-name (.-name package)]
-    (helpers/console! (str "atom disabled package" package-name) :package_manager/on-package-deactivated)
+    (helpers/console! (str "atom disabled package " package-name) :package_manager/on-package-deactivated)
     (disable-package (keyword package-name))))
 
 (defn on-package-activated [package]
   (let [package-name (.-name package)]
-    (helpers/console! (str "atom activated package" package-name) :package_manager/on-package-activated)
+    (helpers/console! (str "atom activated package " package-name) :package_manager/on-package-activated)
     (enable-package (keyword package-name))))
 
 (defn init-subscriptions! []

--- a/src/cljs/proton/lib/proton.cljs
+++ b/src/cljs/proton/lib/proton.cljs
@@ -53,6 +53,11 @@
     (map #(mode-manager/define-mode (get % :mode-name) (dissoc % :mode-name))
      (filter #(not (nil? (get % :mode-name))) (map #(layerbase/describe-mode %) layers)))))
 
+(defn run-init-package-hook [package-name]
+  (if-let [selected-layers (atom-env/get-config "proton.core.selectedLayers")]
+    (let [layers (map keyword (array-seq selected-layers))]
+      (doall (map #(layerbase/init-package [% package-name]) layers)))))
+
 (defn- on-active-pane-item [item]
   (if-let [editor (atom-env/get-active-editor)]
     (when (= (.-id editor) (.-id item))


### PR DESCRIPTION
- Added proto-repl package and appropriate mode keybindings.

- Added layer method `init-package` dispatched by vector [:layer-name
  :package-name]

- Atom specific variables moved from proton.core namespace to
  proton.lib.atom

- Added observers on package disable/enable state.

- `proton.lib.pakackage_manager/enable-package` now executes `package-init`
  hook for associated package.

- `proton.lib.package_manager/disable-package` removes appropriate
  keybindings defined for associated package. Also removes mode defined
  for package from `proton.lib.mode/modes`

- Added `proton.lib.mode/define-package-mode` method to define mode
  based on package name.

- Added conventional method `proton.lib.mode/package-mode-name` to
  generate mode name for specified package.

- Added `proton.lib.mode/link-modes` method to set specified mode as
  child mode for its parent. Parent mode keybindings will be extended
  with child mode keybindings.

- Selected layers stored in __proton.core.selectedLayers__ atom config.

ping  @dvcrn, @spencerlyon2 to review.