### PR TITLE
Winow keybindings improvements.

### DIFF
--- a/src/cljs/proton/config/editor.cljs
+++ b/src/cljs/proton/config/editor.cljs
@@ -66,7 +66,6 @@
                :styleguide
                :symbols-view
                :tabs
-               :theme-switch
                :timecop
                :update-package-dependencies
                :welcome

--- a/src/cljs/proton/layers/core/README.md
+++ b/src/cljs/proton/layers/core/README.md
@@ -22,10 +22,6 @@ The core layer should get included by default. No installation needed.
 Key Binding        | Description
 -------------------|------------------------
 <kbd>SPC 0-9</kbd> | focus on N pane
-<kbd>SPC j</kbd>   | go to pane below
-<kbd>SPC k</kbd>   | go to pane above
-<kbd>SPC l</kbd>   | go to pane on the left
-<kbd>SPC h</kbd>   | go to pane on the right
 <kbd>SPC tab</kbd> | visit last used buffer
 <kbd>SPC SPC</kbd> | easy motion by letter
 
@@ -43,13 +39,19 @@ Key Binding            | Description
 #### Window
 
 Key Binding          | Description
----------------------|--------------------------------
+---------------------|------------------------------------------------
 <kbd> SPC w d </kbd> | Destroy current window / pane
+<kbd> SPC w j </kbd> | Go to pane below
+<kbd> SPC w k </kbd> | Go to pane above
+<kbd> SPC w l </kbd> | Go to pane on the left
+<kbd> SPC w h </kbd> | Go to pane on the right
 <kbd> SPC w v </kbd> | Split vertically
-<kbd> SPC w h </kbd> | Split horizontally
+<kbd> SPC w s </kbd> | Split horizontally
 <kbd> SPC w V </kbd> | Split vertically and focus left
-<kbd> SPC w H </kbd> | Split horizontally and focus up
-<kbd> SPC w m </kbd> | Destroy all other panes (maximise current pane)
+<kbd> SPC w S </kbd> | Split horizontally and focus up
+<kbd> SPC w o </kbd> | Destroy all other panes (maximise current pane)
+<kbd> SPC w m </kbd> | Maximize active pane
+<kbd> SPC w c </kbd> | Close active pane
 
 #### Buffer
 

--- a/src/cljs/proton/layers/core/keybindings.cljs
+++ b/src/cljs/proton/layers/core/keybindings.cljs
@@ -37,18 +37,6 @@
           :9 {:fx (select-window-fn 9)
               :hidden true
               :title "window 9"}
-          :j {:action "window:focus-pane-below"
-              :target actions/get-active-pane
-              :title "focus below pane"}
-          :k {:action "window:focus-pane-above"
-              :target actions/get-active-pane
-              :title "focus above pane"}
-          :l {:action "window:focus-pane-on-right"
-              :target actions/get-active-pane
-              :title "focus right pane"}
-          :h {:action "window:focus-pane-on-left"
-              :target actions/get-active-pane
-              :title "focus left pane"}
           :tab {:action "tab-switcher:next"
                 :title "previous buffer"}
           :space {:action "easy-motion-redux:letter"
@@ -71,23 +59,39 @@
                    :action "advanced-open-file:toggle"}
                := {:action "atom-beautify:beautify-editor" :title "format file"}}
           :w {:category "window"
-              :m {:title "close others"
-                  :fx panes/close-other-panes}
+              :j {:action "window:focus-pane-below"
+                  :target actions/get-active-pane
+                  :title "focus below pane"}
+              :k {:action "window:focus-pane-above"
+                  :target actions/get-active-pane
+                  :title "focus above pane"}
+              :l {:action "window:focus-pane-on-right"
+                  :target actions/get-active-pane
+                  :title "focus right pane"}
+              :h {:action "window:focus-pane-on-left"
+                  :target actions/get-active-pane
+                  :title "focus left pane"}
               :d {:action "pane:close"
                   :target actions/get-active-pane
                   :title "destroy pane"}
               :v {:action "pane:split-right"
                   :target actions/get-active-pane
                   :title "split vertically"}
-              :h {:action "pane:split-down"
+              :s {:action "pane:split-down"
                   :target actions/get-active-pane
                   :title "split horizontally"}
               :V {:action "pane:split-left"
                   :target actions/get-active-pane
                   :title "split vertically and focus left"}
-              :H {:action "pane:split-up"
+              :S {:action "pane:split-up"
                   :target actions/get-active-pane
-                  :title "split horizontally and focus up"}}
+                  :title "split horizontally and focus up"}
+              :m {:action "maximize-panes:maximize"
+                  :title "maximize pane"}
+              :o {:title "close others"
+                  :fx panes/close-other-panes}
+              :c {:action "pane:close"
+                  :title "close pane"}}
          :b {:category "buffer"
               :b {:action "fuzzy-finder:toggle-buffer-finder"
                   :title "browse buffers"}

--- a/src/cljs/proton/layers/core/packages.cljs
+++ b/src/cljs/proton/layers/core/packages.cljs
@@ -9,6 +9,8 @@
      :relative-numbers
      :tab-switcher
      :zentabs
+     :theme-switch
+     :maximize-panes
 
      :recent-files-fuzzy-finder
      :autoupdate-packages


### PR DESCRIPTION
- Window movements via j,k,l,h moved to `SPC w` category to be
  consistent with spacemacs key bindings.
- Added *maximize-pane* package.
- Maximize pane binded to `SPC w m`.
- Added key binding `SPC w c` to close active pane.
- Close other pane key binding moved to `SPC w o`.
- *theme-switch* package moved to `proton.layers.core.packages`.