### PR TITLE
Added more toggles keybindings and expand-region.

### DIFF
--- a/src/cljs/proton/layers/core/README.md
+++ b/src/cljs/proton/layers/core/README.md
@@ -28,6 +28,9 @@ Key Binding        | Description
 <kbd>SPC h</kbd>   | go to pane on the right
 <kbd>SPC tab</kbd> | visit last used buffer
 <kbd>SPC SPC</kbd> | easy motion by letter
+<kbd>SPC v</kbd>   | expand region
+<kbd>SPC ;</kbd>   | toggle line comments
+
 
 #### Files
 
@@ -76,9 +79,14 @@ Key Binding          | Description
 Key Binding          | Description
 ---------------------|-----------------------------
 <kbd> SPC t t </kbd> | Toggle tab bar
-<kbd> SPC t g </kbd> | Toggle line gutter
-<kbd> SPC t n </kbd> | Toggle relative line numbers
+<kbd> SPC t n </kbd> | Toggle line numbers
+<kbd> SPC t r </kbd> | Toggle relative line numbers
 <kbd> SPC t s </kbd> | Toggle status bar
+<kbd> SPC t w </kbd> | Toggle whitespace
+<kbd> SPC t i </kbd> | Toggle indent guide
+<kbd> SPC t I </kbd> | Toggle auto indent
+
+
 
 #### UI toggles/themes
 
@@ -87,7 +95,7 @@ Key Binding          | Description
 <kbd> SPC T F </kbd> | Toggle full screen
 <kbd> SPC T M </kbd> | Toggle maximize
 <kbd> SPC T n </kbd> | Cycle themes
-
+<kbd> SPC T m </kbd> | Toggle menu bar
 
 #### Meta
 

--- a/src/cljs/proton/layers/core/keybindings.cljs
+++ b/src/cljs/proton/layers/core/keybindings.cljs
@@ -122,12 +122,17 @@
                         (do
                           (actions/toggle-tabs true)
                           (swap! state assoc-in [:tabs] true))))}
-             :g {:title "gutter"
+             :n {:title "line numbers"
                  :target (fn [atom] (.getView (.-views atom) (.getActiveTextEditor (.-workspace atom))))
                  :action "editor:toggle-line-numbers"}
+             :i {:action "editor:toggle-indent-guide"
+                 :target "atom-text-editor:not([mini])"
+                 :title "indent guide"}
+             :I {:action "window:toggle-auto-indent"
+                 :title "auto indent"}
              :s {:title "status bar"
                  :action "status-bar:toggle"}
-             :n {:title "relative numbers"
+             :r {:title "relative numbers"
                  :fx (fn []
                        (if (get @state :relative-numbers)
                         (do
@@ -135,12 +140,21 @@
                           (swap! state assoc-in [:relative-numbers] false))
                         (do
                           (actions/toggle-relative-lines true)
-                          (swap! state assoc-in [:relative-numbers] true))))}}
+                          (swap! state assoc-in [:relative-numbers] true))))}
+              :w {:title "whitespace"
+                  :fx (fn [] (atom-env/set-config! "editor.showInvisibles" (not (atom-env/get-config "editor.showInvisibles"))))}}
           :T {:category "UI toggles/themes"
               :F {:action "window:toggle-full-screen" :title "toggle full screen"}
               :M {:fx actions/toggle-maximize :title "toggle maximize"}
-              :n {:action "theme-switch:next" :title "cycle themes"}}
+              :n {:action "theme-switch:next" :title "cycle themes"}
+              :m {:action "window:toggle-menu-bar" :title "toggle menu bar"}}
           :m {:category "mode"}
+          (keyword ";") {:action "editor:toggle-line-comments"
+                         :target "atom-text-editor:not([mini])"
+                         :title "comment lines"}
+          :v {:action "expand-region:expand"
+              :target "atom-text-editor:not([mini])"
+              :title "expand region"}
           :_ {:category "meta"
               :d {:title "find-dotfile"
                   :fx (fn []

--- a/src/cljs/proton/layers/core/packages.cljs
+++ b/src/cljs/proton/layers/core/packages.cljs
@@ -16,6 +16,7 @@
 
      :hyperclick
      :nuclide-file-watcher
+     :expand-region
 
      ;; other
      :advanced-open-file


### PR DESCRIPTION
Added [expand-region](https://atom.io/packages/expand-region) package and binded `expand-region:expand` action to `SPC v`. Also added next toggles:

- `SPC ;` toggle comments
- `SPC t g` renamed and remaped to `SPC t n`
- `SPC t n` renamed and remaped to `SPC t r`
- `SPC t w` toggle whitespace
- `SPC t i` toggle indent guides
- `SPC t I` toggle auto indent
- `SPC T m` toggle menu bar