### PR TITLE
Fixed issue when only left editor marked as target.

### DIFF
--- a/src/cljs/proton/layers/core/keybindings.cljs
+++ b/src/cljs/proton/layers/core/keybindings.cljs
@@ -40,7 +40,7 @@
           :tab {:action "tab-switcher:next"
                 :title "previous buffer"}
           :space {:action "easy-motion-redux:letter"
-                  :target "atom-text-editor:not([mini])"
+                  :target actions/get-active-editor
                   :title "easy motion"}
           (keyword ":") {:action "command-palette:toggle"
                          :title "run command"}
@@ -130,7 +130,7 @@
                  :target (fn [atom] (.getView (.-views atom) (.getActiveTextEditor (.-workspace atom))))
                  :action "editor:toggle-line-numbers"}
              :i {:action "editor:toggle-indent-guide"
-                 :target "atom-text-editor:not([mini])"
+                 :target actions/get-active-editor
                  :title "indent guide"}
              :I {:action "window:toggle-auto-indent"
                  :title "auto indent"}
@@ -156,10 +156,10 @@
               :m {:action "window:toggle-menu-bar" :title "toggle menu bar"}}
           :m {:category "mode"}
           (keyword ";") {:action "editor:toggle-line-comments"
-                         :target "atom-text-editor:not([mini])"
+                         :target actions/get-active-editor
                          :title "comment lines"}
           :v {:action "expand-region:expand"
-              :target "atom-text-editor:not([mini])"
+              :target actions/get-active-editor
               :title "expand region"}
           :_ {:category "meta"
               :d {:title "find-dotfile"

--- a/src/cljs/proton/layers/lang/python/core.cljs
+++ b/src/cljs/proton/layers/lang/python/core.cljs
@@ -1,6 +1,7 @@
 (ns proton.layers.lang.python.core
   (:require [proton.lib.helpers :as helpers]
-            [proton.lib.mode :as mode])
+            [proton.lib.mode :as mode]
+            [proton.layers.core.actions :as actions])
   (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps describe-mode register-layer-dependencies init-package]]))
 
 (defmethod init-layer! :lang/python
@@ -12,21 +13,21 @@
   (mode/define-package-mode :autocomplete-python
     {:mode-keybindings
      {:g {:category "goto"
-          :g {:action "autocomplete-python:go-to-definition" :target "atom-text-editor[data-grammar~=python]:not(.mini)" :title "definition"}}}})
+          :g {:action "autocomplete-python:go-to-definition" :target actions/get-active-editor :title "definition"}}}})
   (mode/link-modes :python-major-mode (mode/package-mode-name :autocomplete-python)))
 
 (defmethod init-package [:lang/python :python-yapf] []
   (mode/define-package-mode :python-yapf
     {:mode-keybindings
-      {:= {:action "python-yapf:formatCode" :target "atom-text-editor:not([mini])" :title "yapf format file"}}})
+      {:= {:action "python-yapf:formatCode" :target actions/get-active-editor :title "yapf format file"}}})
   (mode/link-modes :python-major-mode (mode/package-mode-name :python-yapf)))
 
 (defmethod init-package [:lang/python :python-tools] []
   (mode/define-package-mode :python-tools
     {:mode-keybindings
       {:g {:category "goto"
-           :u {:action "python-tools:show-usages" :target "atom-text-editor:not([mini])" :title "show usages"}}
-       :S {:action "python-tools:select-all-string" :target "atom-text-editor:not([mini])"}}})
+           :u {:action "python-tools:show-usages" :target actions/get-active-editor :title "show usages"}}
+       :S {:action "python-tools:select-all-string" :target actions/get-active-editor}}})
   (mode/link-modes :python-major-mode (mode/package-mode-name :python-tools)))
 
 (defmethod init-package [:lang/python :python-isort] []
@@ -34,7 +35,7 @@
     {:mode-keybindings
       {:r {:category "refactor"
            :i {:category "imports"
-               :s {:action "python-isort:sortImports" :target "atom-text-editor:not([mini])" :title "sort imports"}}}}})
+               :s {:action "python-isort:sortImports" :target actions/get-active-editor :title "sort imports"}}}}})
   (mode/link-modes :python-major-mode (mode/package-mode-name :python-isort)))
 
 (defmethod get-packages :lang/python []


### PR DESCRIPTION
When two panes opened and we have visible two or more editors left editor will be always passed as target to dispatch atom commands when selector string is used as `:target`.