### PR TITLE
Added :s category for selection

### DIFF
--- a/src/cljs/proton/layers/core/README.md
+++ b/src/cljs/proton/layers/core/README.md
@@ -64,6 +64,15 @@ Key Binding          | Description
 <kbd> SPC b K </kbd> | Kill other buffers
 <kbd> SPC b d </kbd> | Delete / destroy current buffer
 
+#### Selection
+
+Key Binding          | Description
+---------------------|-------------------------------------------------------------
+<kbd> SPC s e </kbd> | Expand selection (multi-select all matching words in buffer)
+<kbd> SPC s n </kbd> | Multi-select next word
+<kbd> SPC s s </kbd> | Skip next word for multi-select
+<kbd> SPC s u </kbd> | Undo last select
+
 #### Project
 
 Key Binding          | Description

--- a/src/cljs/proton/layers/core/README.md
+++ b/src/cljs/proton/layers/core/README.md
@@ -64,7 +64,7 @@ Key Binding          | Description
 <kbd> SPC b K </kbd> | Kill other buffers
 <kbd> SPC b d </kbd> | Delete / destroy current buffer
 
-#### Selection
+#### Search
 
 Key Binding          | Description
 ---------------------|-------------------------------------------------------------

--- a/src/cljs/proton/layers/core/keybindings.cljs
+++ b/src/cljs/proton/layers/core/keybindings.cljs
@@ -58,7 +58,7 @@
                :f {:title "advanced-open-file"
                    :action "advanced-open-file:toggle"}
                := {:action "atom-beautify:beautify-editor" :title "format file"}}
-          :s {:category "selection"
+          :s {:category "search"
               :e {:action "find-and-replace:select-all"
                   :target actions/get-active-editor
                   :title "expand selection"}

--- a/src/cljs/proton/layers/core/keybindings.cljs
+++ b/src/cljs/proton/layers/core/keybindings.cljs
@@ -58,6 +58,19 @@
                :f {:title "advanced-open-file"
                    :action "advanced-open-file:toggle"}
                := {:action "atom-beautify:beautify-editor" :title "format file"}}
+          :s {:category "selection"
+              :e {:action "find-and-replace:select-all"
+                  :target actions/get-active-editor
+                  :title "expand selection"}
+              :n {:action "find-and-replace:select-next"
+                  :target actions/get-active-editor
+                  :title "select next"}
+              :s {:action "find-and-replace:select-skip"
+                  :target actions/get-active-editor
+                  :title "skip next"}
+              :u {:action "find-and-replace:select-undo"
+                  :target actions/get-active-editor
+                  :title "undo last select"}}
           :w {:category "window"
               :j {:action "window:focus-pane-below"
                   :target actions/get-active-pane


### PR DESCRIPTION
Available actions:
- <kbd>spc s e</kbd> : select all words matching current selected word (or under cursor)
- <kbd>spc s n</kbd> : select next word
- <kbd>spc s s</kbd> : skip next word
- <kbd>spc s u</kbd> : undo last select