### PR TITLE
added new git keybindings

### DIFF
--- a/src/cljs/proton/layers/tools/git/README.md
+++ b/src/cljs/proton/layers/tools/git/README.md
@@ -19,55 +19,55 @@ Add `:tools/git` to your layers.
 
 #### git
 
-Key Binding    | Description
----------------|-----------------
-<kbd>g L</kbd> | log current file
-<kbd>g r</kbd> | rebase
-<kbd>g A</kbd> | add all files
-<kbd>g m</kbd> | merge
-<kbd>g P</kbd> | push
-<kbd>g B</kbd> | blame
-<kbd>g s</kbd> | status
-<kbd>g l</kbd> | log project
-<kbd>g h</kbd> | file history
-<kbd>g f</kbd> | fetch
-<kbd>g p</kbd> | pull
-<kbd>g a</kbd> | add files
-
-#### git commit
-
-Key Binding      | Description
------------------|-------------
-<kbd>g c c</kbd> | commit
-<kbd>g c C</kbd> | commit all
-<kbd>g c a</kbd> | amend commit
-
-#### git branch
-
-Key Binding      | Description
------------------|-----------------------
-<kbd>g b c</kbd> | checkout branch
-<kbd>g b C</kbd> | create branch
-<kbd>g b r</kbd> | checkout remote branch
-<kbd>g b d</kbd> | delete local branch
-<kbd>g b D</kbd> | delete remote branch
-
-#### git git diff
-
-Key Binding      | Description
------------------|--------------
-<kbd>g d n</kbd> | next diff
-<kbd>g d N</kbd> | previous diff
-<kbd>g d l</kbd> | list diffs
+Key Binding         | Description
+--------------------|-----------------
+<kbd> SPC g L</kbd> | log current file
+<kbd> SPC g r</kbd> | rebase
+<kbd> SPC g A</kbd> | add all files
+<kbd> SPC g m</kbd> | merge
+<kbd> SPC g P</kbd> | push
+<kbd> SPC g B</kbd> | blame
+<kbd> SPC g s</kbd> | status
+<kbd> SPC g l</kbd> | log project
+<kbd> SPC g h</kbd> | file history
+<kbd> SPC g f</kbd> | fetch
+<kbd> SPC g p</kbd> | pull
+<kbd> SPC g a</kbd> | add files
 
 #### git stash
 
-Key Binding      | Description
------------------|------------
-<kbd>g S s</kbd> | stash
-<kbd>g S a</kbd> | apply
-<kbd>g S p</kbd> | pop
-<kbd>g S d</kbd> | drop
+Key Binding           | Description
+----------------------|------------
+<kbd> SPC g S s</kbd> | stash
+<kbd> SPC g S a</kbd> | apply
+<kbd> SPC g S p</kbd> | pop
+<kbd> SPC g S d</kbd> | drop
+
+#### git diff
+
+Key Binding           | Description
+----------------------|--------------
+<kbd> SPC g d n</kbd> | next diff
+<kbd> SPC g d N</kbd> | previous diff
+<kbd> SPC g d l</kbd> | list diffs
+
+#### git branch
+
+Key Binding           | Description
+----------------------|-----------------------
+<kbd> SPC g b c</kbd> | checkout branch
+<kbd> SPC g b C</kbd> | create branch
+<kbd> SPC g b r</kbd> | checkout remote branch
+<kbd> SPC g b d</kbd> | delete local branch
+<kbd> SPC g b D</kbd> | delete remote branch
+
+#### git commit
+
+Key Binding           | Description
+----------------------|-------------
+<kbd> SPC g c c</kbd> | commit
+<kbd> SPC g c C</kbd> | commit all
+<kbd> SPC g c a</kbd> | amend commit
 
 ### Configuration
 

--- a/src/cljs/proton/layers/tools/git/README.md
+++ b/src/cljs/proton/layers/tools/git/README.md
@@ -17,20 +17,57 @@ Add `:tools/git` to your layers.
 
 ### Key Bindings
 
-Key Binding | Description
-------------|----------------------------------
-`SPC g a`   | Git Add Files
-`SPC g S`   | Git Status
-`SPC g s`   | Atomatigit Git Status
-`SPC g P`   | Git Push
-`SPC g c`   | Git Commit
-`SPC g b`   | Toggle Git Blame
-`SPC g L`   | Git Log
-`SPC g l`   | Git Log for Current File
-`SPC g h`   | Git History for Current File
-`SPC g d n` | Git Diff Next Hunk
-`SPC g d N` | Git Diff Previous Hunk
-`SPC g d l` | Toggle Diff List for Current File
+#### git
+
+Key Binding    | Description
+---------------|-----------------
+<kbd>g L</kbd> | log current file
+<kbd>g r</kbd> | rebase
+<kbd>g A</kbd> | add all files
+<kbd>g m</kbd> | merge
+<kbd>g P</kbd> | push
+<kbd>g B</kbd> | blame
+<kbd>g s</kbd> | status
+<kbd>g l</kbd> | log project
+<kbd>g h</kbd> | file history
+<kbd>g f</kbd> | fetch
+<kbd>g p</kbd> | pull
+<kbd>g a</kbd> | add files
+
+#### git commit
+
+Key Binding      | Description
+-----------------|-------------
+<kbd>g c c</kbd> | commit
+<kbd>g c C</kbd> | commit all
+<kbd>g c a</kbd> | amend commit
+
+#### git branch
+
+Key Binding      | Description
+-----------------|-----------------------
+<kbd>g b c</kbd> | checkout branch
+<kbd>g b C</kbd> | create branch
+<kbd>g b r</kbd> | checkout remote branch
+<kbd>g b d</kbd> | delete local branch
+<kbd>g b D</kbd> | delete remote branch
+
+#### git git diff
+
+Key Binding      | Description
+-----------------|--------------
+<kbd>g d n</kbd> | next diff
+<kbd>g d N</kbd> | previous diff
+<kbd>g d l</kbd> | list diffs
+
+#### git stash
+
+Key Binding      | Description
+-----------------|------------
+<kbd>g S s</kbd> | stash
+<kbd>g S a</kbd> | apply
+<kbd>g S p</kbd> | pop
+<kbd>g S d</kbd> | drop
 
 ### Configuration
 

--- a/src/cljs/proton/layers/tools/git/core.cljs
+++ b/src/cljs/proton/layers/tools/git/core.cljs
@@ -16,22 +16,24 @@
        :A {:action "git-plus:add-all" :title "add all files"}
        :s {:action "atomatigit:toggle" :title "status" :target actions/get-active-editor}
        :S {:category "stash"
-           :s {:action "git-plus:stash-save-changes" :title "stash"}
-           :a {:action "git-plus:stash-apply" :title "apply"}
-           :p {:action "git-plus:stash-pop" :title "pop"}
-           :d {:action "git-plus:stash-delete" :title "drop"}}
-       :f {:action "git-plus:fetch"}
-       :r {:action "git-plus:rebase"}
-       :m {:action "git-plus:merge"}
-       :P {:action "git-plus:push" :title "push"}
-       :p {:action "git-plus:pull" :title "pull"}
+           :s {:action "git-plus:stash-save-changes" :title "stash" :target actions/get-active-editor}
+           :a {:action "git-plus:stash-apply" :title "apply" :target actions/get-active-editor}
+           :p {:action "git-plus:stash-pop" :title "pop" :target actions/get-active-editor}
+           :d {:action "git-plus:stash-delete" :title "drop" :target actions/get-active-editor}}
+       :f {:action "git-plus:fetch" :title "fetch" :target actions/get-active-editor}
+       :r {:action "git-plus:rebase" :title "rebase" :target actions/get-active-editor}
+       :m {:action "git-plus:merge" :title "merge" :target actions/get-active-editor}
+       :P {:action "git-plus:push" :title "push" :target actions/get-active-editor}
+       :p {:action "git-plus:pull" :title "pull" :target actions/get-active-editor}
        :c {:category "commit"
-           :c {:action "git-plus:commit" :title "commit"}
-           :C {:action "git-plus:commit-all" :title "commit all"}
-           :a {:action "git-plus:commit-amend" :title "amend commit"}}
+           :c {:action "git-plus:commit" :title "commit" :target actions/get-active-editor}
+           :C {:action "git-plus:commit-all" :title "commit all" :target actions/get-active-editor}
+           :a {:action "git-plus:commit-amend" :title "amend commit" :target actions/get-active-editor}}
        :b {:category "branch"
-           :c {:action "git-plus:checkout" :title "checkout branch"}
-           :C {:action "git-plus:new-branch" :title "create branch"}}
+           :c {:action "git-plus:checkout" :title "checkout branch" :target actions/get-active-editor}
+           :C {:action "git-plus:new-branch" :title "create branch" :target actions/get-active-editor}
+           :d {:action "git-plus:delete-local-branch" :title "delete local branch" :target actions/get-active-editor}
+           :D {:action "git-plus:delete-remote-branch" :title "delete remote branch" :target actions/get-active-editor}}
        :B {:action "blame:toggle" :title "blame" :target actions/get-active-editor}
        :L {:action "git-plus:log-current-file" :target actions/get-active-editor :title "log current file"}
        :l {:action "git-plus:log" :title "log project"}

--- a/src/cljs/proton/layers/tools/git/core.cljs
+++ b/src/cljs/proton/layers/tools/git/core.cljs
@@ -16,10 +16,13 @@
        :A {:action "git-plus:add-all" :title "add all files"}
        :s {:action "atomatigit:toggle" :title "status" :target actions/get-active-editor}
        :S {:category "stash"
-           :s {:action "git-plus:stash-save" :title "save"}
+           :s {:action "git-plus:stash-save-changes" :title "stash"}
+           :a {:action "git-plus:stash-apply" :title "apply"}
            :p {:action "git-plus:stash-pop" :title "pop"}
-           :k {:action "git-plus:stash-keep" :title "keep"}
-           :d {:action "git-plus:stash-drop" :title "drop"}}
+           :d {:action "git-plus:stash-delete" :title "drop"}}
+       :f {:action "git-plus:fetch"}
+       :r {:action "git-plus:rebase"}
+       :m {:action "git-plus:merge"}
        :P {:action "git-plus:push" :title "push"}
        :p {:action "git-plus:pull" :title "pull"}
        :c {:category "commit"

--- a/src/cljs/proton/layers/tools/git/core.cljs
+++ b/src/cljs/proton/layers/tools/git/core.cljs
@@ -32,6 +32,7 @@
        :b {:category "branch"
            :c {:action "git-plus:checkout" :title "checkout branch" :target actions/get-active-editor}
            :C {:action "git-plus:new-branch" :title "create branch" :target actions/get-active-editor}
+           :r {:action "git-plus:checkout-remote" :title "checkout remote branch" :target actions/get-active-editor}
            :d {:action "git-plus:delete-local-branch" :title "delete local branch" :target actions/get-active-editor}
            :D {:action "git-plus:delete-remote-branch" :title "delete remote branch" :target actions/get-active-editor}}
        :B {:action "blame:toggle" :title "blame" :target actions/get-active-editor}

--- a/src/cljs/proton/layers/tools/git/core.cljs
+++ b/src/cljs/proton/layers/tools/git/core.cljs
@@ -13,11 +13,23 @@
   []
   {:g {:category "git"
        :a {:action "git-plus:add" :title "add files"}
-       :S {:action "git-plus:status" :title "git-plus status"}
+       :A {:action "git-plus:add-all" :title "add all files"}
        :s {:action "atomatigit:toggle" :title "status" :target actions/get-active-editor}
+       :S {:category "stash"
+           :s {:action "git-plus:stash-save" :title "save"}
+           :p {:action "git-plus:stash-pop" :title "pop"}
+           :k {:action "git-plus:stash-keep" :title "keep"}
+           :d {:action "git-plus:stash-drop" :title "drop"}}
        :P {:action "git-plus:push" :title "push"}
-       :c {:action "git-plus:commit" :title "commit"}
-       :b {:action "blame:toggle" :title "blame" :target actions/get-active-editor}
+       :p {:action "git-plus:pull" :title "pull"}
+       :c {:category "commit"
+           :c {:action "git-plus:commit" :title "commit"}
+           :C {:action "git-plus:commit-all" :title "commit all"}
+           :a {:action "git-plus:commit-amend" :title "amend commit"}}
+       :b {:category "branch"
+           :c {:action "git-plus:checkout" :title "checkout branch"}
+           :C {:action "git-plus:new-branch" :title "create branch"}}
+       :B {:action "blame:toggle" :title "blame" :target actions/get-active-editor}
        :L {:action "git-plus:log-current-file" :target actions/get-active-editor :title "log current file"}
        :l {:action "git-plus:log" :title "log project"}
        :h {:action "git-history:show-file-history" :target actions/get-active-editor :title "file history"}
@@ -38,7 +50,8 @@
 (defmethod get-keymaps :tools/git []
   [{:selector ".atomatigit .file-list-view" :keymap [["s" "atomatigit:stage"]
                                                      ["d" "atomatigit:toggle-diff"]
-                                                     ["u" "atomatigit:unstage"]]}])
+                                                     ["u" "atomatigit:unstage"]
+                                                     ["q" "core:cancel"]]}])
 
 (defmethod get-initial-config :tools/git [] [])
 


### PR DESCRIPTION
Removed keybindings:
- `g S` (git-plus status is not needed anymore)

Changed keybindings
- `g b` -> `g B` (normal b is better for branching and big B for blaming)
- `g c` -> `g c c` (commit is now a separate category)

New keybindings:
- `g S` - stash category
- `g A` - add all files
- `g p` - git pull
- `g b` - branch category
- `g f` - git fetch
- `g m` - git merge
- `g r` - git rebase

ETC:
- `q` is now closing automatigit when open