### PR TITLE
Added option "proton.core.wipeUserConfigs".

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Check out [all available layers here][4].
 Proton *(name subject to change)* is still in a very early stage. It's pretty usable but keep that in mind before installing.
 
 #### Pre-warning
-Proton tries to be your unified configuration system. Please use a fresh atom installation or backup your existing config as proton will very likely __wipe your settings and packages__. Alternatively make sure your `~/proton` file contains your current configuration. The template you can copy is available [here](https://github.com/dvcrn/proton/blob/master/plugin/templates/proton.edn)
+Proton tries to be your unified configuration system. Please use a fresh atom installation or backup your existing config as proton will very likely __wipe your settings and packages__. Alternatively make sure your `~/proton` file contains your current configuration or add `["proton.core.wipeUserConfigs" false]` to your `~/.proton`. The template you can copy is available [here](https://github.com/dvcrn/proton/blob/master/plugin/templates/proton.edn)
 
 #### Going full proton
 

--- a/src/cljs/proton/core.cljs
+++ b/src/cljs/proton/core.cljs
@@ -91,18 +91,22 @@
         (let [layer-packages (into [] (distinct (concat (proton/packages-for-layers all-layers) additional-packages)))
               all-packages (into [] (distinct (concat layer-packages (:core-packages editor-default))))
               all-keymaps (into [] (distinct (concat keymaps (:keymaps editor-default) (proton/keymaps-for-layers all-layers))))
-              all-keybindings (helpers/deep-merge (proton/keybindings-for-layers all-layers) keybindings)]
+              all-keybindings (helpers/deep-merge (proton/keybindings-for-layers all-layers) keybindings)
+              wipe-configs? (true? (config-map "proton.core.wipeUserConfigs"))]
 
           ;; wipe existing config
-          (atom-env/insert-process-step! "Wiping existing configuration")
-          (doall (map atom-env/unset-config! (filter #(not (or (= "core.themes" %)
-                                                               (= "core.disabledPackages" %)))
-                                                      (atom-env/get-all-settings))))
+
+          (when wipe-configs?
+            (do
+              (atom-env/insert-process-step! "Wiping existing configuration")
+              (doall (map atom-env/unset-config! (filter #(not (or (= "core.themes" %)
+                                                                   (= "core.disabledPackages" %)))
+                                                          (atom-env/get-all-settings))))
+              (atom-env/mark-last-step-as-completed!)))
           (atom-env/set-config! "proton.core.selectedLayers" (clj->js (map #(subs (str %) 1) all-layers)))
           (pm/register-packages all-packages)
           ; avoid duplicates
           (atom-env/set-config! "core.disabledPackages" (distinct (array-seq (atom-env/get-config "core.disabledPackages"))))
-          (atom-env/mark-last-step-as-completed!)
 
           ;; save commands into command tree
           (atom-env/insert-process-step! "Initialising keybinding tree")

--- a/src/cljs/proton/layers/core/README.md
+++ b/src/cljs/proton/layers/core/README.md
@@ -14,6 +14,8 @@ The core layer should get included by default. No installation needed.
 | `proton.core.relativeLineNumbers` | false          | __boolean__ | whether to use relative line numbers instead of absolute ones                              |
 | `proton.core.quickOpenProvider`   | :normal        | __keyword__ | which quickOpen to use. Possible options are `:normal` and `:nuclide`                      |
 | `proton.core.vim-provider`        | :vim-mode-plus | __keyword__ | which vim emulation provider to use. Possible options are `:vim-mode-plus` and `:vim-mode` |
+| `proton.core.wipeUserConfigs`     | true           | __boolean__ | always reset atom configuration before applying conifgs from layers and `~/.proton`        |
+
 
 ### Key Bindings
 

--- a/src/cljs/proton/layers/core/core.cljs
+++ b/src/cljs/proton/layers/core/core.cljs
@@ -27,6 +27,7 @@
    ["proton.core.quickOpenProvider" :normal]
    ["proton.core.post-init-timeout" 3000]
    ["proton.core.vim-provider" :vim-mode-plus]
+   ["proton.core.wipeUserConfigs" true]
 
    ;; vim-mode
    ["vim-mode-plus.useSmartcaseForSearch" true]


### PR DESCRIPTION
"proton.core.wipeUserConfigs" is a boolean. Default value is `true`
which means that atom configurations always reset when proton starts.