### PR TITLE
Bookmarks Layer

### DIFF
--- a/plugin/templates/proton.edn
+++ b/plugin/templates/proton.edn
@@ -20,6 +20,7 @@
     ;; -----------------------------------
     :tools/git
     :tools/linter
+    ;; tools/bookmarks
     ;; :tools/build
     ;; :tools/minimap
 
@@ -29,6 +30,7 @@
     ;; Get more at github.com/dvcrn/proton/tree/master/src/proton/layers/lang
     ;; -----------------------------------
     :lang/clojure
+    ;; lang/csharp
     ;; :lang/python
     ;; :lang/julia
     ;; :lang/latex

--- a/plugin/templates/proton.edn
+++ b/plugin/templates/proton.edn
@@ -20,7 +20,7 @@
     ;; -----------------------------------
     :tools/git
     :tools/linter
-    ;; tools/bookmarks
+    ;; :tools/bookmarks
     ;; :tools/build
     ;; :tools/minimap
 
@@ -30,7 +30,7 @@
     ;; Get more at github.com/dvcrn/proton/tree/master/src/proton/layers/lang
     ;; -----------------------------------
     :lang/clojure
-    ;; lang/csharp
+    ;; :lang/csharp
     ;; :lang/python
     ;; :lang/julia
     ;; :lang/latex

--- a/src/cljs/proton/core.cljs
+++ b/src/cljs/proton/core.cljs
@@ -17,6 +17,7 @@
             [proton.layers.tools.git.core]
             [proton.layers.tools.linter.core]
             [proton.layers.tools.build.core]
+            [proton.layers.tools.bookmarks.core]
 
             ;; etc
             [proton.layers.fun.power_mode.core]

--- a/src/cljs/proton/layers/tools/bookmarks/README.md
+++ b/src/cljs/proton/layers/tools/bookmarks/README.md
@@ -2,7 +2,9 @@
 
 This layer introduces a bookmark category under <kbd>SPC b</kbd>.
 
-This uses the [bookmarks](https://github.com/atom/bookmarks) package.
+Includes the following atom packages:
+
+* [bookmarks](https://github.com/atom/bookmarks) (core atom package)
 
 ### Install
 

--- a/src/cljs/proton/layers/tools/bookmarks/README.md
+++ b/src/cljs/proton/layers/tools/bookmarks/README.md
@@ -1,0 +1,19 @@
+## Bookmarks layer
+
+This layer introduces a bookmark category under <kbd>SPC b</kbd>.
+
+This uses the [bookmarks](https://github.com/atom/bookmarks) package.
+
+### Install
+
+Add `:tools/bookmarks` to your layers.
+
+### Key Bindings
+
+| Key Binding          | Description                     |
+|----------------------|---------------------------------|
+| <kbd> SPC b a </kbd> | view all bookmarks              |
+| <kbd> SPC b b </kbd> | toggle bookmark on current line |
+| <kbd> SPC b c </kbd> | clear all bookmarks             |
+| <kbd> SPC b n </kbd> | jump to next bookmark           |
+| <kbd> SPC b p </kbd> | jump to previous bookmark       |

--- a/src/cljs/proton/layers/tools/bookmarks/README.md
+++ b/src/cljs/proton/layers/tools/bookmarks/README.md
@@ -1,4 +1,4 @@
-## Bookmarks layer
+## Bookmarks configuration layer
 
 This layer introduces a bookmark category under <kbd>SPC b</kbd>.
 

--- a/src/cljs/proton/layers/tools/bookmarks/core.cljs
+++ b/src/cljs/proton/layers/tools/bookmarks/core.cljs
@@ -1,0 +1,37 @@
+(ns proton.layers.tools.bookmarks.core
+  (:require [proton.lib.helpers :as helpers]
+            [proton.layers.core.actions :as actions])
+  (:use [proton.layers.base
+         :only [init-layer! get-initial-config get-keybindings
+                get-packages get-keymaps describe-mode]]))
+
+(defmethod init-layer! :tools/bookmarks
+  [_ {:keys [config layers]}]
+  (helpers/console! "init" :tools/bookmarks))
+
+(defmethod get-keybindings :tools/bookmarks
+  []
+  {:B {:category "bookmarks"
+       :b {:title "toggle bookmark"
+           :action "bookmarks:toggle-bookmark"
+           :target actions/get-active-editor}
+       :n {:title "next bookmark"
+           :action "bookmarks:jump-to-next-bookmark"
+           :target actions/get-active-editor}
+       :p {:title "previous bookmark"
+           :action "bookmarks:jump-to-previous-bookmark"
+           :target actions/get-active-editor}
+       :a {:title "view all"
+           :action "bookmarks:view-all"}
+       :c {:title "clear all"
+           :action "bookmarks:clear-bookmarks"
+           :target actions/get-active-editor}}})
+
+(defmethod get-packages :tools/bookmarks
+  []
+  [:bookmarks])
+
+
+(defmethod get-keymaps :tools/bookmarks [] [])
+(defmethod get-initial-config :tools/bookmarks [] [])
+(defmethod describe-mode :tools/bookmarks [] {})


### PR DESCRIPTION
Just some menu options for the core bookmarks package. I'm not sure this justifies its own layer since it doesn't actually install any new packages. Is this something that should belong in the core layer instead?

Also updated the `proton.edn` with this layer and the csharp layer (which I forgot to do in my last PR).