### PR TITLE
Remove faulty nuclide modules

### DIFF
--- a/plugin/templates/proton.edn
+++ b/plugin/templates/proton.edn
@@ -77,10 +77,6 @@
 
     ;; prefer classic vim mode over vim-mode-plus? Change this to :vim-mode
     ["proton.core.vim-provider" :vim-mode-plus]
-
-    ;; prefer facebooks nuclide quick open instead of the normal atom one?
-    ;; Change the following to :nuclide
-    ["proton.core.quickOpenProvider" :normal]
   ]
 
   ;; Don't like a keybinding or want to add something yourself? Do it here

--- a/src/cljs/proton/layers/core/README.md
+++ b/src/cljs/proton/layers/core/README.md
@@ -12,7 +12,6 @@ The core layer should get included by default. No installation needed.
 |-----------------------------------|----------------|-------------|--------------------------------------------------------------------------------------------|
 | `proton.core.showTabBar`          | false          | __boolean__ | whether the tab bar should be visible by default                                           |
 | `proton.core.relativeLineNumbers` | false          | __boolean__ | whether to use relative line numbers instead of absolute ones                              |
-| `proton.core.quickOpenProvider`   | :normal        | __keyword__ | which quickOpen to use. Possible options are `:normal` and `:nuclide`                      |
 | `proton.core.vim-provider`        | :vim-mode-plus | __keyword__ | which vim emulation provider to use. Possible options are `:vim-mode-plus` and `:vim-mode` |
 | `proton.core.wipeUserConfigs`     | true           | __boolean__ | always reset atom configuration before applying conifgs from layers and `~/.proton`        |
 

--- a/src/cljs/proton/layers/core/core.cljs
+++ b/src/cljs/proton/layers/core/core.cljs
@@ -73,20 +73,7 @@
 
     (case (config-map "proton.core.vim-provider")
       :vim-mode (swap! packages #(into [] (concat % [:vim-mode])))
-      :vim-mode-plus (swap! packages #(into [] (concat % [:vim-mode-plus]))))
-
-    (if (= (config-map "proton.core.quickOpenProvider") :nuclide)
-      (do
-        (swap! packages #(into [] (concat %
-                                    [:nuclide-quick-open
-                                     :nuclide-fuzzy-filename-provider
-                                     :nuclide-open-filenames-provider
-                                     :nuclide-recent-files-provider
-                                     :nuclide-recent-files-service])))
-        (swap! keybindings assoc-in [:p :b :action] "nuclide-open-filenames-provider:toggle-provider")
-        (swap! keybindings assoc-in [:b :b :action] "nuclide-open-filenames-provider:toggle-provider")
-        (swap! keybindings assoc-in [:p :f :action] "nuclide-fuzzy-filename-provider:toggle-provider")
-        (swap! keybindings assoc-in [:p :r :action] "nuclide-recent-files-provider:toggle-provider")))))
+      :vim-mode-plus (swap! packages #(into [] (concat % [:vim-mode-plus]))))))
 
 (defmethod init-package [:core :theme-switch] []
   (let [core-themes (string/join " " (atom-env/get-config "core.themes"))

--- a/src/cljs/proton/layers/core/packages.cljs
+++ b/src/cljs/proton/layers/core/packages.cljs
@@ -18,7 +18,6 @@
      :environment
 
      :hyperclick
-     :nuclide-file-watcher
      :expand-region
 
      ;; other

--- a/src/cljs/proton/layers/core/packages.cljs
+++ b/src/cljs/proton/layers/core/packages.cljs
@@ -17,7 +17,6 @@
      :easy-motion-redux
      :environment
 
-     :hyperclick
      :expand-region
 
      ;; other

--- a/src/cljs/proton/layers/tools/linter/README.md
+++ b/src/cljs/proton/layers/tools/linter/README.md
@@ -6,17 +6,9 @@ This layer adds base support for linting, and introduces the error category unde
 
 Add `:tools/linter` to your layers.
 
-
 ### Configuration
 
-Currently, `tools/linter` allows you to switch between [atom linter](https://github.com/atom-community/linter) and [nuclide diagnostics](https://github.com/facebooknuclideapm/nuclide-diagnostics-ui).
-
-By default, atom linter is being used. If you wish to use nuclide instead, set the following inside your config:
-
-
-Name                     | Default | Type        | Description
--------------------------|---------|-------------|--------------------------------------------------------
-`proton.linter.provider` | :atom   | __keyword__ | which linter to pick? Options are `:atom` or `:nuclide`
+None yet
 
 ### Key Bindings
 

--- a/src/cljs/proton/layers/tools/linter/core.cljs
+++ b/src/cljs/proton/layers/tools/linter/core.cljs
@@ -2,45 +2,27 @@
   (:require [proton.lib.helpers :as helpers])
   (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps describe-mode]]))
 
-(def layer-state (atom {}))
-
-(def linter-keymap
-  {:e {:category "errors"
-         :t {:action "linter:toggle"
-             :title "toggle linter"}
-         :n {:action "linter:next-error"
-             :title "next error"}
-         :p {:action "linter:previous-error"
-             :title "previous error"}
-         :l {:action "linter:lint"
-             :title "lint now"}
-         :T {:action "linter:togglePanel"
-             :title "toggle panel"}}})
-
-(def nuclide-keymap
-  {:e {:category "errors"
-         :s {:action "nuclide-diagnostics-ui:toggle-table"
-             :title "show errors"
-             :target (fn [atom] (.getView (.-views atom) (.-workspace atom)))}}})
-
 (defmethod init-layer! :tools/linter
   [_ {:keys [config layers]}]
-  (helpers/console! "init" :tools/linter)
-  (let [config-map (into (hash-map) config)]
-    (swap! layer-state assoc :provider (config-map "proton.linter.provider"))))
-
-(defmethod get-initial-config :tools/linter []
-  [["proton.linter.provider" :atom]])
+  (helpers/console! "init" :tools/linter))
 
 (defmethod get-packages :tools/linter []
-  (case (@layer-state :provider)
-    :nuclide [:nuclide-diagnostics-ui :nuclide-diagnostics-store]
-    :atom [:linter]))
+  [:linter])
 
 (defmethod get-keybindings :tools/linter [] []
-  (case (@layer-state :provider)
-    :atom linter-keymap
-    :nuclide nuclide-keymap))
+  {:e {:category "errors"
+       :t {:action "linter:toggle"
+           :title "toggle linter"}
+       :n {:action "linter:next-error"
+           :title "next error"}
+       :p {:action "linter:previous-error"
+           :title "previous error"}
+       :l {:action "linter:lint"
+           :title "lint now"}
+       :T {:action "linter:togglePanel"
+           :title "toggle panel"}}})
+
 
 (defmethod describe-mode :tools/linter [] {})
 (defmethod get-keymaps :tools/linter [] [])
+(defmethod get-initial-config :tools/linter [] [])


### PR DESCRIPTION
With the recent change to single package nuclide, our nuclide integration no longer works. We need to either 

a) break out nuclide
b) replace nuclide with the unified package (https://github.com/dvcrn/proton/issues/101)

As a short term fix I removed `nuclide-file-watcher` which is the only nuclide package we use inside core and breaks immediately. 