### PR TITLE
Prevent error caused by ENV variables without values

### DIFF
--- a/src/cljs/proton/lib/helpers.cljs
+++ b/src/cljs/proton/lib/helpers.cljs
@@ -137,7 +137,7 @@
       false)))
 
 (defn- parse-env [env]
-  (into (hash-map) (map #(string/split % #"=") (string/split env #"\n"))))
+  (into (hash-map) (filter #(> (count %) 1) (map #(string/split % #"=") (string/split env #"\n")))))
 
 (defn sync-env-path! []
   (when-not (= js/process.platform "win32")


### PR DESCRIPTION
For me error was thrown due to empty value of __LC_CTYPE__ variable on Mac.