### PR TITLE
Add simple toggle for spell-check

### DIFF
--- a/src/cljs/proton/layers/core/keybindings.cljs
+++ b/src/cljs/proton/layers/core/keybindings.cljs
@@ -165,6 +165,8 @@
                  :title "auto indent"}
              :s {:title "status bar"
                  :action "status-bar:toggle"}
+             :S {:title "spell checking"
+                 :action "spell-check:toggle"}
              :g {:title "golden ratio"
                  :action "golden-ratio:toggle"}
              :r {:title "relative numbers"


### PR DESCRIPTION
I was hoping to add more functionality (e.g. change dictionary), but [spell-check](https://github.com/atom/spell-check) hasn't implemented many of features yet.

I was also going to add a keybinding for "correct spelling", but spell-check uses a popup that shadows any further `SPC` actions. That means you have to use `CTRL+SHIFT+:" to exit the spell-check popup ಠ__ಠ .

As an alternative, I was considering binding `ESC` to `core:cancel`. If you like, I can add that. So it would be `SPC e c` perhaps to correct current word spelling, and then `ESC` to cancel.

Btw, to test changes, should I just build the local proton git repository?