### PR TITLE
Remove deprecated elixir-docs

### DIFF
--- a/src/cljs/proton/layers/lang/elixir/core.cljs
+++ b/src/cljs/proton/layers/lang/elixir/core.cljs
@@ -18,19 +18,13 @@
 (defmethod get-packages :lang/elixir []
   [:language-elixir
    :autocomplete-elixir
-   :elixir-docs
    :iex])
 
 (defmethod describe-mode :lang/elixir []
   {:mode-name :elixir
    :atom-grammars ["Elixir"]
    :mode-keybindings
-   {:d {:category "docs"
-        :t {:action "elixir-docs:toggle"
-            :title "Toggle docs"}
-        :f {:action "elixir-docs:finddoc"
-            :title "Find in docs"}}
-    :i {:category "iex"
+   {:i {:category "iex"
         :l {:action "iex:open-split-right"
             :title "create right"}
         :h {:action "iex:open-split-left"


### PR DESCRIPTION
The author of `elixir-docs` has abandoned it and removed it so this no longer works with the `:lang/elixir` layer.

https://github.com/Psvensso/elixir-docs#-deprecated-

This removes the package and the keybindings.

I'm not familiar with clojurescript syntax so this needs to be verified. :)