### PR TITLE
Add highlight-line toggle to core

### DIFF
--- a/src/cljs/proton/layers/core/keybindings.cljs
+++ b/src/cljs/proton/layers/core/keybindings.cljs
@@ -162,6 +162,9 @@
              :n {:title "line numbers"
                  :target (fn [atom] (.getView (.-views atom) (.getActiveTextEditor (.-workspace atom))))
                  :action "editor:toggle-line-numbers"}
+             :h {:category "highlight"
+                 :h {:title "highlight current line"
+                     :action "highlight-line:toggle-background"}}
              :i {:action "editor:toggle-indent-guide"
                  :target actions/get-active-editor
                  :title "indent guide"}

--- a/src/cljs/proton/layers/core/packages.cljs
+++ b/src/cljs/proton/layers/core/packages.cljs
@@ -30,4 +30,5 @@
      :atom-material-syntax
 
      :file-icons
-     :highlight-selected]))
+     :highlight-selected
+     :highlight-line]))


### PR DESCRIPTION
Needs testing as I'm not sure how to run this locally.

I _think_ the keybindings should work but I'm not 100% sure.