### PR TITLE
Window close undo

### DIFF
--- a/src/cljs/proton/layers/core/keybindings.cljs
+++ b/src/cljs/proton/layers/core/keybindings.cljs
@@ -122,7 +122,9 @@
               :o {:title "close others"
                   :fx panes/close-other-panes}
               :c {:action "pane:close"
-                  :title "close pane"}}
+                  :title "close pane"}
+              :u {:action "open last-closed window"
+                  :title "pane:reopen-closed-item"}}
          :b {:category "buffer"
               :b {:action "fuzzy-finder:toggle-buffer-finder"
                   :title "browse buffers"}


### PR DESCRIPTION
`SPC w u` is a nice shortcut when you accidentally close a pane. Used it far too often in Spacemacs. :)