### PR TITLE
Added ink package to clojure layer

### DIFF
--- a/src/cljs/proton/layers/lang/clojure/core.cljs
+++ b/src/cljs/proton/layers/lang/clojure/core.cljs
@@ -51,6 +51,7 @@
 
 (defmethod get-packages :lang/clojure []
   [:Parinfer
+   :ink
    :proto-repl])
 
 (defmethod describe-mode :lang/clojure []


### PR DESCRIPTION
Since proto-repl 0.13.0 `inlineResults` configuration enabled by default.