### PR TITLE
Fix close buffer keybinding

### DIFF
--- a/src/cljs/proton/layers/core/keybindings.cljs
+++ b/src/cljs/proton/layers/core/keybindings.cljs
@@ -144,7 +144,7 @@
               :K {:action "pane:close-other-items"
                   :target actions/get-active-pane
                   :title "kill other buffers"}
-              :d {:action "pane:close"
+              :d {:action "core:close"
                   :target actions/get-active-pane
                   :title "destroy current buffer"}}
          :p {:category "project"


### PR DESCRIPTION
Previously, it closed the window, not the buffer (to use emacs terms)