### PR TITLE
Handle disallowed keywords chars with aliases. Fix #156

### DIFF
--- a/src/cljs/proton/core.cljs
+++ b/src/cljs/proton/core.cljs
@@ -78,7 +78,7 @@
         (atom-env/deactivate-proton-mode!)
         (do
           ;; append new key to chain
-          (swap! current-chain conj (keyword (helpers/normalize-keystroke keystroke)))
+          (swap! current-chain conj (keyword (helpers/keystroke->keybinding keystroke)))
           ;; check if the current character sequence is a action
           (let [keymaps (keymap-manager/find-keybindings @current-chain)]
             (if (or (nil? keymaps) (empty? keymaps))

--- a/src/cljs/proton/layers/core/keybindings.cljs
+++ b/src/cljs/proton/layers/core/keybindings.cljs
@@ -56,7 +56,7 @@
           :h {:action "window:focus-pane-on-left"
               :target actions/get-active-pane
               :title "focus left pane"}
-          (keyword ":") {:action "command-palette:toggle"
+          :colon {:action "command-palette:toggle"
                          :title "run command"}
           :f {:category "files"
                :e {:category "editor(atom)"
@@ -162,8 +162,8 @@
                  :title "edit projects"}
              :r {:action "recent-files-fuzzy-finder:toggle-finder"
                  :title "recent files"}
-             (keyword "/") {:action "project-find:show"
-                            :title "search in files"}}
+             :slash {:action "project-find:show"
+                     :title "search in files"}}
          :t {:category "toggles"
              :t {:title "tab-bar"
                  :fx (fn []
@@ -208,9 +208,9 @@
               :n {:action "theme-switch:next" :title "cycle themes"}
               :m {:action "window:toggle-menu-bar" :title "toggle menu bar"}}
           :m {:category "mode"}
-          (keyword ";") {:action "editor:toggle-line-comments"
-                         :target actions/get-active-editor
-                         :title "comment lines"}
+          :semicolon {:action "editor:toggle-line-comments"
+                      :target actions/get-active-editor
+                      :title "comment lines"}
           :v {:action "expand-region:expand"
               :target actions/get-active-editor
               :title "expand region"}

--- a/src/cljs/proton/lib/helpers.cljs
+++ b/src/cljs/proton/lib/helpers.cljs
@@ -15,13 +15,26 @@
                          192 "/"
                          9 "tab"})
 
-(defn normalize-keystroke
+(def keystroke->keybinding-map
+   {"/" :slash
+    ":" :colon
+    ";" :semicolon})
+
+(defn keystroke->keybinding
   "Remove 'shift-' prefix from keystroke. For uppercase letter atom keystroke will be
   'shift-<capital_letter>' e.g. :S equal to 'shift-S'."
   [keystroke]
   (if (zero? (.indexOf keystroke "shift-"))
     (last keystroke)
-    keystroke))
+    (if-let [keybinding (get keystroke->keybinding-map keystroke)]
+      keybinding
+      keystroke)))
+
+(defn keybinding->keystroke [keybinding]
+  (let [keystroke (filter (comp #{(keyword keybinding)} keystroke->keybinding-map) (keys keystroke->keybinding-map))]
+    (if-not (empty? keystroke)
+      (first keystroke)
+      keybinding)))
 
 (defn generate-div [text class-name]
   (let [d (.createElement js/document "div")]
@@ -72,7 +85,7 @@
         is-category? ((comp not nil?) category)
         class-name (if is-category? "proton-key-category" "proton-key-action")
         value (if is-category? (str "+" category) (or title action))
-        keystroke (-> keybinding first str rest join)]
+        keystroke (-> keybinding first str rest join keybinding->keystroke)]
       (str "<li class='flex-item'><span class='proton-key'>[" keystroke "]</span> ➜ <span class='" class-name "'>" value "</span></li>")))
 
 (defn show-item? [[_ options]]


### PR DESCRIPTION
Following symbols affected:
- ; as :semicolon
- : as :colon
- / as :slash

So these symbols should be used in key bindings inside `.proton` and across the layers.