### PR TITLE
fix(configuration): add option to specify scopeSelector

### DIFF
--- a/src/cljs/proton/core.cljs
+++ b/src/cljs/proton/core.cljs
@@ -99,7 +99,7 @@
           editor-default editor-config/default
           proton-default proton-config/default]
       (let [all-layers (into [] (distinct (concat (:layers proton-default) layers)))
-            all-configuration (into [] (into (hash-map) (distinct (concat (:settings editor-default) (proton/configs-for-layers all-layers) configuration))))
+            all-configuration (reduce helpers/config-reducer [] (distinct (concat (:settings editor-default) (proton/configs-for-layers all-layers) configuration)))
             config-map (into (hash-map) all-configuration)]
 
         (atom-env/insert-process-step! "Initialising layers")
@@ -155,7 +155,7 @@
 
           ;; set the user config
           (atom-env/insert-process-step! "Applying user configuration")
-          (doall (map #(atom-env/set-config! (get % 0) (get % 1)) all-configuration))
+          (doall (map #(apply atom-env/set-config! %) all-configuration))
           (atom-env/mark-last-step-as-completed!)
 
           ;; Make sure all collected packages are definitely enabled

--- a/src/cljs/proton/lib/atom.cljs
+++ b/src/cljs/proton/lib/atom.cljs
@@ -51,9 +51,12 @@
 (defn get-config [selector]
   (.get config selector))
 
-(defn set-config! [selector value]
-  (console! (str "Setting " selector " to " (clj->js value)))
-  (.set config selector (clj->js value)))
+(defn set-config!
+  ([selector value]
+   (set-config! selector value {}))
+  ([selector value opts]
+   (console! (str "Setting " selector " to " (clj->js value) " options: " (clj->js opts)))
+   (.set config selector (clj->js value) (clj->js opts))))
 
 (defn add-to-config! [selector value]
   (let [previous-config (js->clj (.get config selector))]

--- a/src/cljs/proton/lib/helpers.cljs
+++ b/src/cljs/proton/lib/helpers.cljs
@@ -175,3 +175,18 @@
                   (console! (str "New $PATH: " js/process.env.PATH) :helpers/sync-env-path))))
             (close! path-chan))
           (close! path-chan))))))
+
+(defn config-reducer
+   "Push config to collection if no exists or it has options value.
+    Options is 3-rd element in vector. e.g. ['editor.tabLength' 2 {:scopeSelector ['.source.ruby']}]
+    Update config value when no options passed."
+   [coll config]
+  (let [config-name (first config)
+        matched (filter #(= (key %) config-name) coll)
+        matched-no-opts (first (filter #(= 2 (count %)) matched))]
+    (if (empty? matched)
+      (conj coll config)
+      ;; check for options
+      (if (nth config 2 false)
+        (conj coll config)
+        (conj (remove #{matched-no-opts} coll) config)))))


### PR DESCRIPTION
There is no way to specify `scopeSelector` option for configurations
specified in `.proton`. Added 3-rd optional value with _hash-map_ type passed to
configuration. For example in `.proton`
```
;; .proton
...

:configuration
[
  ["editor.tabLength" 2 {:scopeSelector [".source.python" ".source.ruby"]}]
]
```