### PR TITLE
added support for multi actions for keybindings

### DIFF
--- a/src/cljs/proton/lib/atom.cljs
+++ b/src/cljs/proton/lib/atom.cljs
@@ -137,8 +137,14 @@
         (.dispatch commands dom-target action)))
     (deactivate-proton-mode!)))
 
+(defn eval-actions! [action-vector]
+  (doall (map eval-action! action-vector))
+  (reset! last-action action-vector))
+
 (defn eval-last-action! []
-  (eval-action! @last-action))
+  (if (vector? @last-action)
+    (eval-actions! @last-action)
+    (eval-action! @last-action)))
 
 (defn get-all-settings []
   (let [config-obj (.getAll config)

--- a/src/cljs/proton/lib/keymap.cljs
+++ b/src/cljs/proton/lib/keymap.cljs
@@ -1,7 +1,7 @@
 (ns proton.lib.keymap
   #_(:require [proton.core]
               [proton.lib.mode])
-  (:require [proton.lib.atom :as atom-env :refer [workspace commands views eval-action!]]
+  (:require [proton.lib.atom :as atom-env :refer [workspace commands views eval-action! eval-actions!]]
             [proton.lib.helpers :as helpers :refer [deep-merge]]))
 
 (defonce atom-keymap (atom {}))
@@ -47,7 +47,10 @@
       (get-in keymap ks)))
 
 (defn exec-binding [keymap-item]
-  (atom-env/eval-action! keymap-item))
+  ;; if it is a vector, it means we are dealing with a multi keybinding
+  (if (vector? keymap-item)
+    (eval-actions! keymap-item)
+    (eval-action! keymap-item)))
 
 (defn is-action? [{:keys [fx action]}]
   (not (nil? (or fx action))))


### PR DESCRIPTION
This adds support for executing multiple actions with one keybindings.
The donation is a vector. If the command is a vector instead of a map, it will execute all maps inside the vector