### PR TITLE
fix(html/autoclose-html): Remove init-package hook for autoclose-html package

### DIFF
--- a/src/cljs/proton/layers/lang/html/core.cljs
+++ b/src/cljs/proton/layers/lang/html/core.cljs
@@ -17,10 +17,6 @@
     [:linter-bootlint
      :linter-xmllint]))
 
-(defmethod init-package [:lang/html :autoclose-html] []
-  (let [additionalGrammars (array-seq (atom-env/get-config "autoclose-html.additionalGrammars"))]
-    (atom-env/set-config! "autoclose-html.additionalGrammars" (distinct (concat additionalGrammars ["XSL" "XML"])))))
-
 (defmethod init-package [:lang/html :emmet] []
   (mode/define-package-mode :emmet
     {:mode-keybindings


### PR DESCRIPTION
`autoclose-html.additionalGrammars` config was removed since 0.22.0
version. We used this config to setup XML specific grammars.
Refs #173 