### PR TITLE
refactor(core): remove `move-pane` bindings from root

### DIFF
--- a/src/cljs/proton/layers/core/keybindings.cljs
+++ b/src/cljs/proton/layers/core/keybindings.cljs
@@ -56,16 +56,8 @@
           :h {:action "window:focus-pane-on-left"
               :target actions/get-active-pane
               :title "focus left pane"}
-          :H {:action "move-panes:move-left"
-              :title "move pane left"}
-          :J {:action "move-panes:move-down"
-              :title "move pane down"}
-          :K {:action "move-panes:move-up"
-              :title "move pane up"}
-          :L {:action "move-panes:move-right"
-              :title "move pane right"}
           :colon {:action "command-palette:toggle"
-                         :title "run command"}
+                  :title "run command"}
           :f {:category "files"
                :e {:category "editor(atom)"
                    :d {:title "find-dotfile"


### PR DESCRIPTION
`move-pane` bindings were cluttering the root namespace. Since this is usually a action that is not that commonly performed, It is better to have it under `w` only and not in the root space as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dvcrn/proton/175)
<!-- Reviewable:end -->
