### PR TITLE
fix cljs.core conflict issue

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,10 +5,10 @@
             :url "https://github.com/dvcrn/proton/blob/master/LICENSE.md"}
 
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/clojurescript "1.7.170"]
+                 [org.clojure/clojurescript "1.7.228"]
                  [org.clojure/core.async "0.2.374"]]
 
   :source-paths ["src/cljs"]
   :profiles {:dev {:source-paths ["src/dev"]
-                   :dependencies [[thheller/shadow-build "1.0.192"]
+                   :dependencies [[thheller/shadow-build "1.0.207"]
                                   [thheller/shadow-devtools "0.1.35"]]}})

--- a/src/cljs/proton/core.cljs
+++ b/src/cljs/proton/core.cljs
@@ -60,7 +60,7 @@
             [proton.config.proton :as proton-config]
 
             [cljs.core.async :as async :refer [chan put! pub sub unsub >! <!]]
-            [clojure.string]))
+            ))
 
 ;; Atom for holding all disposables objects
 (def disposables (atom []))

--- a/src/dev/build.clj
+++ b/src/dev/build.clj
@@ -6,6 +6,8 @@
 
 (defn- plugin-setup []
   (-> (cljs/init-state)
+      (cljs/set-build-options
+        {:node-global-prefix "global.PROTON"})
       (cljs/find-resources-in-classpath)
       (umd/create-module
         {:activate 'proton.core/activate
@@ -44,6 +46,7 @@
         {:before-load 'proton.core/stop
          :after-load 'proton.core/start
          :reload-with-state true
+         :console-support true
          :node-eval true}
         (fn [state modified]
           (-> state


### PR DESCRIPTION
When multiple cljs-based UMD libraries are loaded they all abuse the same `global` object, eventually leading to conflicts since they may be using different versions of cljs.

A new feature in shadow-build allows prefixing the `global` object so instead of using `global` it is now using `global.PROTON`. So proton code no longer conflicts with anything else.

Any other cljs based library not compiled with this prefix change will however still conflict with each other but not proton. `proto-repl` is still causing issues, but with itself.