### PR TITLE
feat(spotify): add spotify layer

### DIFF
--- a/src/cljs/proton/core.cljs
+++ b/src/cljs/proton/core.cljs
@@ -23,6 +23,7 @@
 
             ;; etc
             [proton.layers.fun.power_mode.core]
+            [proton.layers.fun.spotify.core]
 
             ;; langs
             [proton.layers.lang.clojure.core]
@@ -60,8 +61,8 @@
             [proton.config.editor :as editor-config]
             [proton.config.proton :as proton-config]
 
-            [cljs.core.async :as async :refer [chan put! pub sub unsub >! <!]]
-            ))
+            [cljs.core.async :as async :refer [chan put! pub sub unsub >! <!]]))
+
 
 ;; Atom for holding all disposables objects
 (def disposables (atom []))

--- a/src/cljs/proton/layers/fun/spotify/README.md
+++ b/src/cljs/proton/layers/fun/spotify/README.md
@@ -1,0 +1,19 @@
+# Spotify Layer
+
+Adds [spotify-remote](https://github.com/theHazzard/spotify-remote) support
+
+## Install
+
+Add `:fun/spotify` to your layers.
+
+## Usage
+
+Use <kbd>SPC a m s</kbd>
+
+### Key Bindings
+
+Key Binding            | Description
+-----------------------|---------------------
+<kbd>SPC a m s p</kbd> | Toggle play/pause
+<kbd>SPC a m s n</kbd> | Play next track
+<kbd>SPC a m s b</kbd> | Play previous track

--- a/src/cljs/proton/layers/fun/spotify/core.cljs
+++ b/src/cljs/proton/layers/fun/spotify/core.cljs
@@ -1,0 +1,25 @@
+(ns proton.layers.spotify.core
+  (:use [proton.layers.base :only [init-layer! get-initial-config et-keybindings get-packages get-keymaps]]))
+
+(defmethod init-layer! :fun/spotify
+  [_ {:keys [config layers]}])
+
+(defmethod get-keybindings :fun/spotify
+  []
+  {:a {:category "applications"
+        :m {:category "music"
+            :s {:category "spotify"
+                :p {:action "spotify-remote:toggle"
+                    :title "play/pause"}
+                :n {:action "spotify-remote:next"
+                    :title "Plat next song"}
+                :b {:action "spotify-remote:previous"
+                    :title "Play previous song"}}}}})
+
+(defmethod get-packages :fun/spotify
+  []
+  [:spotify-remote])
+
+(defmethod get-keymaps :fun/spotify [] [])
+(defmethod get-initial-config :fun/spotify [] [])
+(defmethod describe-mode :fun/spotify [] {})


### PR DESCRIPTION
A new layer is added to the fun section that wraps the spotify-remote package

https://github.com/theHazzard/spotify-remote