### PR TITLE
refactor(lang/python): replace pep8 linter with flake8

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Closes #8454
         commit type       /                /      
                 \        |                |
                  feat(ngInclude): add template url parameter to events
-            
+
         body ->  The 'src` (i.e. the url of the template to load) is now provided to the
                  `$includeContentRequested`, `$includeContentLoaded` and `$includeContentError`
                  events.
@@ -39,13 +39,16 @@ Closes #8454
 ```
 
 For the commit type, use the matching type from this list:
-- feat
-- fix
-- docs
-- style
-- refactor
-- test
-- chore
+- **feat**: A new feature
+- **fix**: A bug fix
+- **docs**: Documentation only changes
+- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing
+  semi-colons, etc)
+- **refactor**: A code change that neither fixes a bug nor adds a feature
+- **perf**: A code change that improves performance
+- **test**: Adding missing tests
+- **chore**: Changes to the build process or auxiliary tools and libraries such as documentation
+  generation
 
 ### Summary
 
@@ -53,7 +56,7 @@ Please use __present tense__ inside your commit message at all time. Keywords li
 
 ### Linking to github
 
-Here as well, please make sure that you use the __present tense__ for `Closes` and `Fixes` and add `References #XX` before referencing a github issue if you are not closing it. Please write these keywords in __uppercase__. 
+Here as well, please make sure that you use the __present tense__ for `Closes` and `Fixes` and add `References #XX` before referencing a github issue if you are not closing it. Please write these keywords in __uppercase__.
 
 ## Pull requests
 Pull requests are currently submitted to `master`. This might change in the future so please keep an eye on this.

--- a/src/cljs/proton/layers/lang/python/README.md
+++ b/src/cljs/proton/layers/lang/python/README.md
@@ -1,12 +1,12 @@
 ## Python configuration layer
 
-Adds better python autocomplete and formatting to Atom powered by [jedi](https://github.com/davidhalter/jedi). Linting is done through pep8.
+Adds better python autocomplete and formatting to Atom powered by [jedi](https://github.com/davidhalter/jedi). Linting is done through flake8.
 
 Includes following atom packages:
 
 - [autocomplete-python](https://atom.io/packages/autocomplete-python)
 - [python-tools](https://atom.io/packages/python-tools)
-- [linter-pep8](https://atom.io/packages/linter-pep8)
+- [linter-flake8](https://atom.io/packages/linter-flake8)
 - [python-isort](https://atom.io/packages/python-isort)
 
 ### Install
@@ -18,13 +18,13 @@ For django support include `:frameworks/django` to your layers.
 
 - [yapf](https://github.com/google/yapf)
 - [jedi](https://github.com/davidhalter/jedi)
-- [pep8](http://pep8.readthedocs.org/en/latest/intro.html)
+- [flake8](http://flake8.readthedocs.org/en/latest/intro.html)
 - [isort](https://github.com/timothycrosley/isort)
 
 ### Configuration
-- `linter-pep8.ignoreErrorCodes`: a array of pep8 error codes to ignore
-- `linter-pep8.pep8ExecutablePath`: which pep8 executable to use
-- `linter-pep8.maxLineLength`: your max line length
+- `linter-flake8.ignoreErrorCodes`: a array of flake8 error codes to ignore
+- `linter-flake8.executablePath`: which flake8 executable to use
+- `linter-flake8.maxLineLength`: your max line length
 
 ### Mode Key Binding
 

--- a/src/cljs/proton/layers/lang/python/core.cljs
+++ b/src/cljs/proton/layers/lang/python/core.cljs
@@ -7,7 +7,7 @@
 (defmethod init-layer! :lang/python
   [_ {:keys [config layers]}]
   (helpers/console! "init" :lang/python)
-  (register-layer-dependencies :tools/linter [:linter-pep8]))
+  (register-layer-dependencies :tools/linter [:linter-flake8]))
 
 (defmethod init-package [:lang/python :autocomplete-python] []
   (mode/define-package-mode :autocomplete-python


### PR DESCRIPTION
Flake8 includes pep8 and more;

- PyFlakes
- pep8
- Ned Batchelder’s McCabe script