### PR TITLE
switch project-manager to project-plus

### DIFF
--- a/src/cljs/proton/layers/core/keybindings.cljs
+++ b/src/cljs/proton/layers/core/keybindings.cljs
@@ -168,12 +168,14 @@
                  :title "tree-view"}
              :f {:action "fuzzy-finder:toggle-file-finder"
                  :title "find in project"}
-             :p {:action "project-manager:list-projects"
+             :p {:action "project-plus:toggle-project-finder"
                  :title "switch projects"}
-             :s {:action "project-manager:save-project"
+             :s {:action "project-plus:save"
                  :title "save project"}
-             :e {:action "project-manager:edit-projects"
-                 :title "edit projects"}
+             :c {:action "project-plus:close"
+                 :title "close project"}
+             :l {:action "project-plus:open"
+                 :title "open folder as project"}
              :r {:action "recent-files-fuzzy-finder:toggle-finder"
                  :title "recent files"}
              :slash {:action "project-find:show"

--- a/src/cljs/proton/layers/core/packages.cljs
+++ b/src/cljs/proton/layers/core/packages.cljs
@@ -21,7 +21,7 @@
 
      ;; other
      :advanced-open-file
-     :project-manager
+     :project-plus
      :golden-ratio
      :autocomplete-paths
 


### PR DESCRIPTION
I find project-plus far more reliable (and useful) than project-manager.

This PR also adds keybindings for 'project close' and 'open folder as project' (`SPC p l` inspired by spacemacs-layouts) and removes `SPC p e` as project-plus has no equivalent.