### PR TITLE
fix(.proton): Don’t install clojure layer by default

### DIFF
--- a/plugin/templates/proton.edn
+++ b/plugin/templates/proton.edn
@@ -29,7 +29,7 @@
     ;; Languages
     ;; Get more at github.com/dvcrn/proton/tree/master/src/proton/layers/lang
     ;; -----------------------------------
-    :lang/clojure
+    ;; :lang/clojure
     ;; :lang/csharp
     ;; :lang/python
     ;; :lang/julia


### PR DESCRIPTION
I don’t have Clojure or Java installed on my machine so when I edit my .proton file with this layer installed, [this dialog pops up constantly](https://cloud.githubusercontent.com/assets/602654/14617314/f31bf7ba-056a-11e6-9a9d-c6e02edbdde1.png).
