### PR TITLE
feat(lang/markdown): add markdown-toc

### DIFF
--- a/src/cljs/proton/layers/lang/markdown/README.md
+++ b/src/cljs/proton/layers/lang/markdown/README.md
@@ -1,29 +1,56 @@
-## Markdown Configuration Layer
+# Markdown Configuration Layer
+
+<!-- MDTOC maxdepth:6 firsth1:1 numbering:0 flatten:0 bullets:1 updateOnSave:1 -->
+
+- [Markdown Configuration Layer](#markdown-configuration-layer)   
+   - [Install](#install)   
+   - [Key Bindings](#key-bindings)   
+      - [Insert](#insert)   
+      - [Format](#format)   
+      - [Toggle](#toggle)   
+      - [Preview](#preview)   
+
+<!-- /MDTOC -->
 
 Adds markdown support to proton.
 
 Includes following atom packages:
 
-- [md-writer](https://atom.io/packages/markdown-writer)
-- [markdown-preview](https://atom.io/packages/markdown-preview)
-- [markdown-scroll-sync](https://atom.io/packages/markdown-scroll-sync)
-- [linter-markdown](https://atom.io/packages/linter-markdown)
+-  [md-writer](https://atom.io/packages/markdown-writer)
+-  [markdown-preview](https://atom.io/packages/markdown-preview)
+-  [markdown-scroll-sync](https://atom.io/packages/markdown-scroll-sync)
+-  [linter-markdown](https://atom.io/packages/linter-markdown)
+-  [markdown-toc](https://atom.io/packages/markdown-toc)
 
-### Install
+## Install
 
 Add `:lang/markdown` to your layers.
 
 For linter support add `:tools/linter` to your layers.
 
-### Key Bindings
+## Key Bindings
+
+### Insert
+
+Key Binding          | Description
+---------------------|-------------
+<kbd>SPC m i l</kbd> | Insert Link
+<kbd>SPC m i i</kbd> | Insert Image
+<kbd>SPC m i t</kbd> | Insert Table
+
+
+### Format
 
 Key Binding            | Description
 -----------------------|-----------------------------
-<kbd>SPC m i l</kbd>   | Insert Link
-<kbd>SPC m i i</kbd>   | Insert Image
-<kbd>SPC m i t</kbd>   | Insert Table
 <kbd>SPC m f t</kbd>   | Format Table
 <kbd>SPC m f o</kbd>   | Correct Order List Numbers
+
+
+### Toggle
+
+Key Binding            | Description
+-----------------------|-----------------------------
 <kbd>SPC m t c</kbd>   | Toggle Code Text
 <kbd>SPC m t b</kbd>   | Toggle Bold Text
 <kbd>SPC m t i</kbd>   | Toggle Italic Text
@@ -39,6 +66,11 @@ Key Binding            | Description
 <kbd>SPC m t h 3</kbd> | Togle H3
 <kbd>SPC m t h 4</kbd> | Togle H4
 <kbd>SPC m t h 5</kbd> | Togle H5
+
+### Preview
+
+Key Binding            | Description
+-----------------------|-----------------------------
 <kbd>SPC m p t</kbd>   | Toggle Preview
 <kbd>SPC m p i</kbd>   | Zoom In in Preview Window
 <kbd>SPC m p o</kbd>   | Zoom Out in Preview Window

--- a/src/cljs/proton/layers/lang/markdown/core.cljs
+++ b/src/cljs/proton/layers/lang/markdown/core.cljs
@@ -24,13 +24,22 @@
   []
   [:markdown-writer
    :markdown-preview
-   :markdown-scroll-sync])
+   :markdown-scroll-sync
+   :atom-mdtoc])
 
 (defmethod get-keymaps :lang/markdown
   []
   [{:selector "atom-workspace atom-text-editor.autocomplete-active:not([mini])[data-grammar~='gfm']"
     :keymap [["enter" "autocomplete-plus:confirm"]
              ["tab" "autocomplete-plus:confirm"]]}])
+
+(defmethod init-package [:lang/markdown :atom-mdtoc] []
+  (mode/define-package-mode :atom-mdtoc
+    {:mode-keybindings
+      {:T {:category "TOC"
+           :i {:action "atom-mdtoc:insert" :title "Insert TOC"}
+           :d {:action "atom-mdtoc:delete" :title "Delete TOC"}}}})
+  (mode/link-modes :markdown-major-mode (mode/package-mode-name :atom-mdtoc)))
 
 (defmethod init-package [:lang/markdown :markdown-writer] []
   (helpers/console! "init markdown-writer package" :lang/markdown)
@@ -76,4 +85,4 @@
 (defmethod describe-mode :lang/markdown
   []
   {:mode-name :markdown-major-mode
-   :atom-scope ["source.gfm" "source.litcoffee" "text.md"]})
+   :atom-scope ["source.gfm" "source.litcoffee" "text.md" "source.markdown"]})


### PR DESCRIPTION
Add [atom-mdtoc](http://atom.io/packages/atom-mdtoc) for automatic TOC generation.