### PR TITLE
Add npm-debug.log to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ pom.xml
 node_modules/
 out/
 plugin/lib/
+npm-debug.log


### PR DESCRIPTION
No comments necessary -- this was missing
