### PR TITLE
fix(*): escape apm path for atom beta

### DIFF
--- a/src/cljs/proton/layers/lang/clojure/core.cljs
+++ b/src/cljs/proton/layers/lang/clojure/core.cljs
@@ -45,7 +45,7 @@
            :X {:action "proto-repl:super-refresh-namespaces" :title "super refresh"}}
        :t {:category "tests"
            :a {:action "proto-repl:run-all-tests" :title "run all"}
-           :t {:action "proto-repl:run-selected-test" :title "run selected"}
+           :t {:action "proto-repl:run-test-under-cursor" :title "run selected"}
            :c {:action "proto-repl:run-tests-in-namespace" :title "run in ns"}}}})
   (mode/link-modes :clojure-major-mode (mode/package-mode-name :proto-repl)))
 

--- a/src/cljs/proton/lib/atom.cljs
+++ b/src/cljs/proton/lib/atom.cljs
@@ -53,7 +53,8 @@
   (.isVisible @bottom-panel))
 
 (defn get-apm-path []
-  (.getApmPath packages))
+  (-> (.getApmPath packages)
+      (clojure.string/replace " " "\\ ")))
 
 (defn get-config [selector]
   (.get config selector))


### PR DESCRIPTION
Noticed that packages weren't being installed/removed in beta, '/Applications/Atom\ Beta.app' :)

Not quite sure why it's showing as 2x commits...