### PR TITLE
Update shadow-build to fix dev-repl namespace

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,14 +1,14 @@
 (defproject proton "0.1.0-SNAPSHOT"
-  :description "Spacemacs helps Atom to become a better editor"
-  :url "https://github.com/dvcrn/proton/"
-  :license {:name "GPLv3"
-            :url "https://github.com/dvcrn/proton/blob/master/LICENSE.md"}
+ :description "Spacemacs helps Atom to become a better editor"
+ :url "https://github.com/dvcrn/proton/"
+ :license {:name "GPLv3"
+           :url "https://github.com/dvcrn/proton/blob/master/LICENSE.md"}
 
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/clojurescript "1.7.228"]
-                 [org.clojure/core.async "0.2.374"]]
+ :dependencies [[org.clojure/clojure "1.7.0"]
+                [org.clojure/clojurescript "1.7.228"]
+                [org.clojure/core.async "0.2.374"]]
 
-  :source-paths ["src/cljs"]
-  :profiles {:dev {:source-paths ["src/dev"]
-                   :dependencies [[thheller/shadow-build "1.0.207"]
-                                  [thheller/shadow-devtools "0.1.35"]]}})
+ :source-paths ["src/cljs"]
+ :profiles {:dev {:source-paths ["src/dev"]
+                  :dependencies [[thheller/shadow-build "1.0.213"]
+                                 [thheller/shadow-devtools "0.1.35"]]}})


### PR DESCRIPTION
There were namespace conflicts within atom with other plugins written in
clojurescript. On request, @thheller fixed the issue in shadow-build.