### PR TITLE
fix(*): add escaping to apm path

### DIFF
--- a/src/cljs/proton/lib/atom.cljs
+++ b/src/cljs/proton/lib/atom.cljs
@@ -53,7 +53,8 @@
   (.isVisible @bottom-panel))
 
 (defn get-apm-path []
-  (.getApmPath packages))
+  (-> (.getApmPath packages)
+      (clojure.string/replace " " "\\ ")))
 
 (defn get-config [selector]
   (.get config selector))


### PR DESCRIPTION
All better; forgot I hadn't updated from upstream! 😅 