### PR TITLE
feat(core): Provide option to chose input mode for non-vim users.

### DIFF
--- a/plugin/templates/proton.edn
+++ b/plugin/templates/proton.edn
@@ -88,7 +88,7 @@
     ["proton.core.relativeLineNumbers" false]
 
     ;; prefer classic vim mode over vim-mode-plus? Change this to :vim-mode
-    ["proton.core.vim-provider" :vim-mode-plus]
+    ["proton.core.inputProvider" :vim-mode-plus]
   ]
 
   ;; Don't like a keybinding or want to add something yourself? Do it here

--- a/src/cljs/proton/config/editor.cljs
+++ b/src/cljs/proton/config/editor.cljs
@@ -5,7 +5,10 @@
                ["welcome.showOnStartup" false]
 
                ;; Better default font ;)
-               ["editor.fontFamily" "Hack"]]
+               ["editor.fontFamily" "Hack"]
+               ["proton.core.leaderKey" "space"]
+               ["proton.core.modeKey" ","]
+               ["proton.core.inputProvider" :vim-mode-plus]]
 
               :keymaps
                []

--- a/src/cljs/proton/core.cljs
+++ b/src/cljs/proton/core.cljs
@@ -173,6 +173,7 @@
           ;; set the user config
           (atom-env/insert-process-step! "Applying user configuration")
           (doall (map #(apply atom-env/set-config! %) all-configuration))
+          (proton/show-deprecated-configs all-configuration)
           (atom-env/mark-last-step-as-completed!)
 
           ;; Make sure all collected packages are definitely enabled

--- a/src/cljs/proton/layers/core/README.md
+++ b/src/cljs/proton/layers/core/README.md
@@ -8,15 +8,18 @@ The core layer should get included by default. No installation needed.
 
 ### Configuration
 
-| Name                              | Default        | Type        | Description                                                                                |
-|-----------------------------------|----------------|-------------|--------------------------------------------------------------------------------------------|
-| `proton.core.showTabBar`          | false          | __boolean__ | whether the tab bar should be visible by default                                           |
-| `proton.core.relativeLineNumbers` | false          | __boolean__ | whether to use relative line numbers instead of absolute ones                              |
-| `proton.core.vim-provider`        | :vim-mode-plus | __keyword__ | which vim emulation provider to use. Possible options are `:vim-mode-plus` and `:vim-mode` |
-| `proton.core.wipeUserConfigs`     | true           | __boolean__ | always reset atom configuration before applying conifgs from layers and `~/.proton`        |
-| `proton.core.whichKeyDelay`       | 0.4            | __number__  | which-key modal delay in seconds                                                           |
-| `proton.core.whichKeyDelayOnInit` | false          | __boolean__ | which-key modal delay for first show up and no delay when shown                            |
-| `proton.core.whichKeyDisabled` | false          | __boolean__ | which-key modal always hidden |
+| Name                              | Default        | Type        | Description                                                                                                                                 |
+|-----------------------------------|----------------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| `proton.core.showTabBar`          | false          | __boolean__ | whether the tab bar should be visible by default                                                                                            |
+| `proton.core.relativeLineNumbers` | false          | __boolean__ | whether to use relative line numbers instead of absolute ones                                                                               |
+| `proton.core.vim-provider`        | :vim-mode-plus | __keyword__ | which vim emulation provider to use. Possible options are `:vim-mode-plus` and `:vim-mode`                                                  |
+| `proton.core.wipeUserConfigs`     | true           | __boolean__ | always reset atom configuration before applying conifgs from layers and `~/.proton`                                                         |
+| `proton.core.whichKeyDelay`       | 0.4            | __number__  | which-key modal delay in seconds                                                                                                            |
+| `proton.core.whichKeyDelayOnInit` | false          | __boolean__ | which-key modal delay for first show up and no delay when shown                                                                             |
+| `proton.core.whichKeyDisabled`    | false          | __boolean__ | which-key modal always hidden                                                                                                               |
+| `proton.core.inputProvider`       | :vim-mode-plus | __keyword__ | editor input. available options are :vim-mode-plus, :vim-mode, :emacs, :default. You need to reload editor to apply changes properly |
+| `proton.core.leaderKey`           | "space"        | __string__  | proton leader key binding. For non-vim modes its value is `alt-m` if not set manualy by user                                                |
+| `proton.core.modeKey`             | ","            | __string__  | proton major mode key alias to quickly invoke `SPC m`. For non-vim modes its value is `ctrl-alt-m` if not set by user                       |
 
 
 ### Key Bindings

--- a/src/cljs/proton/layers/core/core.cljs
+++ b/src/cljs/proton/layers/core/core.cljs
@@ -9,6 +9,9 @@
             [proton.lib.atom :as atom-env :refer [get-config set-config! set-keymap!]]
             [cljs.nodejs :as node]))
 
+(defn- add-packages [p]
+  (swap! packages #(into [] (concat % p))))
+
 (def keymaps (atom
               [{:selector "body" :keymap [["ctrl-j" "core:move-down"]
                                           ["ctrl-k" "core:move-up"]]}
@@ -26,7 +29,6 @@
    ["proton.core.relativeLineNumbers" false]
    ["proton.core.quickOpenProvider" :normal]
    ["proton.core.post-init-timeout" 3000]
-   ["proton.core.vim-provider" :vim-mode-plus]
    ["proton.core.wipeUserConfigs" true]
    ["proton.core.whichKeyDelay" 0.4]
    ["proton.core.whichKeyDelayOnInit" false]
@@ -69,9 +71,12 @@
     (swap! state assoc-in [:relative-numbers] (config-map "proton.core.relativeLineNumbers"))
     (swap! state assoc-in [:tabs] (config-map "proton.core.showTabBar"))
 
-    (case (config-map "proton.core.vim-provider")
-      :vim-mode (swap! packages #(into [] (concat % [:vim-mode :vim-surround])))
-      :vim-mode-plus (swap! packages #(into [] (concat % [:vim-mode-plus :vim-mode-plus-ex-mode]))))))
+    ;; install additional packages based on proton.core.inputProvider if needed
+    (case (config-map "proton.core.inputProvider")
+      :vim-mode (add-packages [:vim-mode :vim-surround])
+      :vim-mode-plus (add-packages [:vim-mode-plus :vim-mode-plus-ex-mode])
+      :emacs (add-packages [:atomic-emacs])
+      :default)))
 
 (defmethod init-package [:core :theme-switch] []
   (let [core-themes (string/join " " (atom-env/get-config "core.themes"))

--- a/src/cljs/proton/lib/atom.cljs
+++ b/src/cljs/proton/lib/atom.cljs
@@ -23,6 +23,7 @@
 (def grammars (.-grammars (.-grammars js/atom)))
 (def workspace-view (.getView views workspace))
 (def packages (.-packages js/atom))
+(def notifications (.-notifications js/atom))
 
 (def element (atom (generate-div "test" "proton-which-key")))
 (def bottom-panel (atom (.addBottomPanel workspace
@@ -99,20 +100,22 @@
   (amend-last-step! (str (get (last @steps) 0)) "<span class='proton-status-ok'>[ok]</span>"))
 
 (defn input-provider-class []
-  (if-let [selected-provider (get-config "proton.core.vim-provider")]
+  (if-let [selected-provider (get-config "proton.core.inputProvider")]
     (do
       (case selected-provider
         "vim-mode" ["vim-mode"]
-        "vim-mode-plus" ["vim-mode-plus"]))
-    [""]))
+        "vim-mode-plus" ["vim-mode-plus"]
+        []))
+    []))
 
 (defn editor-toggle-classes [class-list remove?]
-  (let [editors (.getTextEditors workspace)]
-    (doseq [editor editors]
-      (let [editor-view (.getView views editor)
-            classList (.-classList editor-view)
-            class-list-fn (fn [class-name] (if remove? (.remove classList class-name) (.add classList class-name)))]
-        (doall (map class-list-fn class-list))))))
+  (when (not (empty? class-list))
+    (let [editors (.getTextEditors workspace)]
+      (doseq [editor editors]
+        (let [editor-view (.getView views editor)
+              classList (.-classList editor-view)
+              class-list-fn (fn [class-name] (if remove? (.remove classList class-name) (.add classList class-name)))]
+          (doall (map class-list-fn class-list)))))))
 
 (defn activate-proton-mode! []
   (console! "Chain activated!")
@@ -169,7 +172,6 @@
               (fn [val config-postfix _]
                 (swap! parsed-config conj (str config-prefix "." config-postfix))))))))
     @parsed-config))
-
 
 (defn set-keymap!
   ([selector bindings]

--- a/src/cljs/proton/lib/helpers.cljs
+++ b/src/cljs/proton/lib/helpers.cljs
@@ -143,7 +143,8 @@
         ignored-editor-classes #{"insert-mode" "mini"}
         ignored-editor-class-ok? (empty? (cljset/intersection class-list ignored-editor-classes))
         required-editor-classes #{"vim-mode" "vim-mode-plus"}
-        required-editor-class-ok? (not (empty? (cljset/intersection class-list required-editor-classes)))]
+        vim-mode? (some #{(js/atom.config.get "proton.core.inputProvider")} ["vim-mode" "vim-mode-plus"])
+        required-editor-class-ok? (or (not (empty? (cljset/intersection class-list required-editor-classes))) (not vim-mode?))]
     (if tag-ok?
       (if (= tag-name "atom-text-editor")
         (and required-editor-class-ok? ignored-attrs-ok? ignored-editor-class-ok?)


### PR DESCRIPTION
* Added option `proton.core.inputProvider` with default value `:vim-mode-plus`. Available options are `:vim-mode-plus`, `:vim-mode`, `:atomic-emacs`, `:default`
* Added deprecated warning for `proton.core.vim-provider` option.
* Added options `proton.core.leaderKey` and `proton.core.modeKey` to configure leader and major mode alias keystrokes
* Added info regarding `proton.core.leaderKey`, `proton.core.modeKey`, `proton.core.inputProvider` to core layer Readme.

@dvcrn review please.