### PR TITLE
Replaced terminal-plus package with platformio-ide-terminal

### DIFF
--- a/src/cljs/proton/layers/tools/terminal/core.cljs
+++ b/src/cljs/proton/layers/tools/terminal/core.cljs
@@ -8,12 +8,12 @@
 
 (defmethod get-keybindings :tools/terminal
   []
-  {:' {:action "terminal-plus:toggle"
-        :title "terminal"}})
+  {:quote {:action "platformio-ide-terminal:toggle"
+           :title "terminal"}})
 
 (defmethod get-packages :tools/terminal
   []
-  [:terminal-plus])
+  [:platformio-ide-terminal])
 
 (defmethod get-keymaps :tools/terminal [] [])
 (defmethod get-initial-config :tools/terminal [] [])


### PR DESCRIPTION
It should fix #225 .

The only problem I have locally is that `'` binding - it does not work for me (it didn't work with `terminal-plus` either). If I replace it with some other character i.e. `a`:

```clojure
  {:a {:action "platformio-ide-terminal:toggle"
        :title "terminal"}})
```

It works. Is there something wrong with my local config?