### PR TITLE
feat(tools/expose): add exposé buffer switching

### DIFF
--- a/src/cljs/proton/core.cljs
+++ b/src/cljs/proton/core.cljs
@@ -14,6 +14,7 @@
 
             ;; tools
             [proton.layers.tools.minimap.core]
+            [proton.layers.tools.expose.core]
             [proton.layers.tools.git.core]
             [proton.layers.tools.linter.core]
             [proton.layers.tools.build.core]

--- a/src/cljs/proton/layers/tools/expose/README.md
+++ b/src/cljs/proton/layers/tools/expose/README.md
@@ -1,0 +1,13 @@
+## Exposé layer
+
+This layer adds the exposé package for switching buffers visually under the keybinding `<spc> b e`. If the minimap layer is installed, it will show a preview for each buffer.
+
+### Install
+
+Add `:tools/expose` to your layers.
+
+### Key Bindings
+
+Key Binding            | Description
+-----------------------|--------------
+<kbd> SPC b e </kbd>   | Toggle exposé

--- a/src/cljs/proton/layers/tools/expose/core.cljs
+++ b/src/cljs/proton/layers/tools/expose/core.cljs
@@ -1,0 +1,20 @@
+(ns proton.layers.tools.expose.core
+  (:require [proton.lib.helpers :as helpers])
+  (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps describe-mode]]))
+
+(defmethod init-layer! :tools/expose
+  [_ {:keys [config layers]}]
+  (helpers/console! "init" :tools/expose))
+
+(defmethod get-keybindings :tools/expose
+  []
+  {:b {:e {:action "expose:toggle"
+           :title "exposé"}}})
+
+(defmethod get-packages :tools/expose
+  []
+  [:expose])
+
+(defmethod get-initial-config :tools/expose [] [])
+(defmethod get-keymaps :tools/expose [] [])
+(defmethod describe-mode :tools/expose [] {})


### PR DESCRIPTION
Adds the `:tools/expose` layer for exposé, which provides a nice graphical buffer switch. If the minimap is installed, it shows a preview too. The keybinding is <kbd>SPC b e</kbd>. 

![screencast](https://cloud.githubusercontent.com/assets/6207820/19857836/1b092c92-9f77-11e6-9d79-9c41c5665320.gif)