### PR TITLE
fix(core): which-key panel not appearing in Atom 1.13.0

### DIFF
--- a/src/cljs/proton/lib/helpers.cljs
+++ b/src/cljs/proton/lib/helpers.cljs
@@ -133,7 +133,7 @@
 
 
 (defn is-proton-target? [e]
-  (let [target (.-target e)
+  (let [target (or (.closest (.-target e) "atom-text-editor") (.-target e))
         tag-name (string/lower-case (.-tagName target))
         class-list (set (array-seq (.-classList target)))
         ignored-tags #{"input" "textarea"}


### PR DESCRIPTION
which-key not appearing because of changes related to event target
passed to command dispatcher. In this particular case event target
was `input.class-hidden` instead of `atom-text-editor.vim-mode-plus`.
Changes related to removing shadow dom from atom.

@dvcrn, @richarddewit can you please test this changes?