### PR TITLE
feat(core): Skip welcome unless package changes

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -3,6 +3,7 @@
 - [proton manual](#proton-manual)   
    - [.proton](#proton)   
       - [Editor configuration](#editor-configuration)   
+      - [Configuring proton core itself](#configuring-proton-core-itself)
       - [Syntax specific configuration](#syntax-specific-configuration)   
       - [Custom SPC keybinding](#custom-spc-keybinding)   
       - [Editor keymaps](#editor-keymaps)   
@@ -35,6 +36,15 @@ would result in 2 vectors:
 ```
 ["editor.fontFamily" "Hack"]
 ["editor.softWrap" true]
+```
+
+### Configuring proton core itself
+
+There are several settings that allow users to customize proton's behaviour. These are under the `proton.core` namespace and can be seen [README for the core layer](/src/cljs/proton/layers/core/README.md). To set them to values other than the defaults add a row to your `.proton` file as above. For example:
+
+```
+;; Prefer to skip the welcome screen if there is nothing important being shown
+["proton.core.alwaysShowWelcomeScreen" false]
 ```
 
 ### Syntax specific configuration

--- a/src/cljs/proton/layers/core/README.md
+++ b/src/cljs/proton/layers/core/README.md
@@ -8,18 +8,19 @@ The core layer should get included by default. No installation needed.
 
 ### Configuration
 
-| Name                              | Default        | Type        | Description                                                                                                                                 |
-|-----------------------------------|----------------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| `proton.core.showTabBar`          | false          | __boolean__ | whether the tab bar should be visible by default                                                                                            |
-| `proton.core.relativeLineNumbers` | false          | __boolean__ | whether to use relative line numbers instead of absolute ones                                                                               |
-| `proton.core.vim-provider`        | :vim-mode-plus | __keyword__ | which vim emulation provider to use. Possible options are `:vim-mode-plus` and `:vim-mode`                                                  |
-| `proton.core.wipeUserConfigs`     | true           | __boolean__ | always reset atom configuration before applying conifgs from layers and `~/.proton`                                                         |
-| `proton.core.whichKeyDelay`       | 0.4            | __number__  | which-key modal delay in seconds                                                                                                            |
-| `proton.core.whichKeyDelayOnInit` | false          | __boolean__ | which-key modal delay for first show up and no delay when shown                                                                             |
-| `proton.core.whichKeyDisabled`    | false          | __boolean__ | which-key modal always hidden                                                                                                               |
-| `proton.core.inputProvider`       | :vim-mode-plus | __keyword__ | editor input. available options are :vim-mode-plus, :vim-mode, :emacs, :default. You need to reload editor to apply changes properly |
-| `proton.core.leaderKey`           | "space"        | __string__  | proton leader key binding. For non-vim modes its value is `alt-m` if not set manualy by user                                                |
-| `proton.core.modeKey`             | ","            | __string__  | proton major mode key alias to quickly invoke `SPC m`. For non-vim modes its value is `ctrl-alt-m` if not set by user                       |
+| Name                                  | Default        | Type        | Description                                                                                                                                 |
+|---------------------------------------|----------------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| `proton.core.alwaysShowWelcomeScreen` | true           | __boolean__ | whether the welcome screen is always shown, even when there are only expected messages.
+| `proton.core.showTabBar`              | false          | __boolean__ | whether the tab bar should be visible by default                                                                                            |
+| `proton.core.relativeLineNumbers`     | false          | __boolean__ | whether to use relative line numbers instead of absolute ones                                                                               |
+| `proton.core.vim-provider`            | :vim-mode-plus | __keyword__ | which vim emulation provider to use. Possible options are `:vim-mode-plus` and `:vim-mode`                                                  |
+| `proton.core.wipeUserConfigs`         | true           | __boolean__ | always reset atom configuration before applying conifgs from layers and `~/.proton`                                                         |
+| `proton.core.whichKeyDelay`           | 0.4            | __number__  | which-key modal delay in seconds                                                                                                            |
+| `proton.core.whichKeyDelayOnInit`     | false          | __boolean__ | which-key modal delay for first show up and no delay when shown                                                                             |
+| `proton.core.whichKeyDisabled`        | false          | __boolean__ | which-key modal always hidden                                                                                                               |
+| `proton.core.inputProvider`           | :vim-mode-plus | __keyword__ | editor input. available options are :vim-mode-plus, :vim-mode, :emacs, :default. You need to reload editor to apply changes properly |
+| `proton.core.leaderKey`               | "space"        | __string__  | proton leader key binding. For non-vim modes its value is `alt-m` if not set manualy by user                                                |
+| `proton.core.modeKey`                 | ","            | __string__  | proton major mode key alias to quickly invoke `SPC m`. For non-vim modes its value is `ctrl-alt-m` if not set by user                       |
 
 
 ### Key Bindings

--- a/src/cljs/proton/layers/core/core.cljs
+++ b/src/cljs/proton/layers/core/core.cljs
@@ -29,6 +29,7 @@
    ["proton.core.relativeLineNumbers" false]
    ["proton.core.quickOpenProvider" :normal]
    ["proton.core.post-init-timeout" 3000]
+   ["proton.core.alwaysShowWelcomeScreen" true]
    ["proton.core.wipeUserConfigs" true]
    ["proton.core.whichKeyDelay" 0.4]
    ["proton.core.whichKeyDelayOnInit" false]


### PR DESCRIPTION
[Updated PR description describing latest version of the behaviour]

Added a configuration option to skip showing the welcoming dialog box if there are no packages to add
or remove.

By default the welcome screen is still always shown, to enable the new behaviour set
`proton.core.alwaysShowWelcomeScreen` to false.