### PR TITLE
fix(tools/linter) changed commands and packages according latest linter

### DIFF
--- a/src/cljs/proton/layers/tools/linter/README.md
+++ b/src/cljs/proton/layers/tools/linter/README.md
@@ -13,14 +13,12 @@ None yet
 ### Key Bindings
 
 Key Binding          | Description
----------------------|------------
-<kbd> SPC e s </kbd> | Show errors
-
-#### :atom mode
-
-Key Binding          | Description
 ---------------------|------------------
 <kbd> SPC e t </kbd> | Toggle linter
+<kbd> SPC e T </kbd> | Toggle linter panel
 <kbd> SPC e n </kbd> | Next error
 <kbd> SPC e p </kbd> | Previous error
+<kbd> SPC e N </kbd> | Next error in current file
+<kbd> SPC e P </kbd> | Previous error in current file
 <kbd> SPC e l </kbd> | Lint current file
+<kbd> SPC e f </kbd> | Apply all solutions

--- a/src/cljs/proton/layers/tools/linter/core.cljs
+++ b/src/cljs/proton/layers/tools/linter/core.cljs
@@ -1,29 +1,36 @@
 (ns proton.layers.tools.linter.core
   (:require [proton.lib.helpers :as helpers])
-  (:use [proton.layers.base :only [init-layer! get-initial-config get-keybindings get-packages get-keymaps describe-mode]]))
+  (:use [proton.layers.base :only [init-layer! get-keybindings get-packages get-keymaps describe-mode]]))
 
 (defmethod init-layer! :tools/linter
   [_ {:keys [config layers]}]
   (helpers/console! "init" :tools/linter))
 
 (defmethod get-packages :tools/linter []
-  [:linter])
+  [:linter-ui-default
+   :busy-signal
+   :intentions
+   :linter])
 
 (defmethod get-keybindings :tools/linter [] []
   {:e {:category "errors"
-       :t {:action "linter:toggle"
+       :t {:action "linter:toggle-active-editor"
            :title "toggle linter"}
-       :n {:action "linter:next-error"
+       :n {:action "linter-ui-default:next"
            :title "next error"}
-       :p {:action "linter:previous-error"
+       :p {:action "linter-ui-default:previous"
            :title "previous error"}
+       :N {:action "linter-ui-default:next-error-in-current-file"
+           :title "next error in current file"}
+       :P {:action "linter-ui-default:previous-error-in-current-file"
+           :title "previous error in current file"}
        :l {:action "linter:lint"
            :title "lint now"}
-       :T {:action "linter:togglePanel"
-           :title "toggle panel"}}})
+       :T {:action "linter-ui-default:toggle-panel"
+           :title "toggle panel"}
+       :f {:action "linter-ui-default:apply-all-solutions"
+           :title "apply all solutions"}}})
 
 
 (defmethod describe-mode :tools/linter [] {})
 (defmethod get-keymaps :tools/linter [] [])
-(defmethod get-initial-config :tools/linter []
-  [["linter.statusIconScope" "File"]])


### PR DESCRIPTION
* Linter v2 has following dependencies linter-ui-default, intentsions and busy-signal
 which will be removed since they are not included in tools/linter layer.
* Updated keybinding actions