### PR TITLE
fix(linter): Update keybinds for new linter [Jack Casey]

### DIFF
--- a/src/cljs/proton/layers/tools/linter/README.md
+++ b/src/cljs/proton/layers/tools/linter/README.md
@@ -21,6 +21,7 @@ Key Binding          | Description
 Key Binding          | Description
 ---------------------|------------------
 <kbd> SPC e t </kbd> | Toggle linter
-<kbd> SPC e n </kbd> | Next error
-<kbd> SPC e p </kbd> | Previous error
+<kbd> SPC e n </kbd> | Next
+<kbd> SPC e p </kbd> | Previous
 <kbd> SPC e l </kbd> | Lint current file
+<kbd> SPC e T </kbd> | Toggle linter panel

--- a/src/cljs/proton/layers/tools/linter/core.cljs
+++ b/src/cljs/proton/layers/tools/linter/core.cljs
@@ -11,15 +11,15 @@
 
 (defmethod get-keybindings :tools/linter [] []
   {:e {:category "errors"
-       :t {:action "linter:toggle"
-           :title "toggle linter"}
-       :n {:action "linter:next-error"
+       :t {:action "linter:toggle-active-editor"
+           :title "toggle for active file"}
+       :n {:action "linter-ui-default:next"
            :title "next error"}
-       :p {:action "linter:previous-error"
+       :p {:action "linter-ui-default:previous"
            :title "previous error"}
        :l {:action "linter:lint"
            :title "lint now"}
-       :T {:action "linter:togglePanel"
+       :T {:action "linter-ui-default:toggle-panel"
            :title "toggle panel"}}})
 
 


### PR DESCRIPTION
The new linter overhaul in the recent atom changes some keybinds, this simply reinstates the old behaviour as much as possible.