### PR TITLE
fix(modal): force modal spacing to all themes

### DIFF
--- a/plugin/styles/proton.less
+++ b/plugin/styles/proton.less
@@ -89,14 +89,16 @@
   max-height: 500px;
   overflow-y: scroll;
   margin: 20px 0;
-  padding: 0px 12px;
+  padding: 0px 12px !important;
 
   h2 {
     color: @text-color-success;
+    margin: 0 !important;
   }
 
   table {
     width: 100%;
+    margin: 10px 0 !important;
   }
 
   tr {


### PR DESCRIPTION
Some external themes were messing with the spacing of the modal panel by
setting paddings and margins. This adds !important rules to make sure
the spacing looks the same on all themes.