### PR TITLE
remove :environment from core layer because of deprecation of package

### DIFF
--- a/src/cljs/proton/layers/core/packages.cljs
+++ b/src/cljs/proton/layers/core/packages.cljs
@@ -15,7 +15,6 @@
      :recent-files-fuzzy-finder
      :autoupdate-packages
      :easy-motion-redux
-     :environment
 
      :expand-region
 


### PR DESCRIPTION
Solves issue #269

I think we just need to remove the package, it seemed like an easy PR