### PR TITLE
fix(core):remove vim-mode-plus-ex-mode

### DIFF
--- a/src/cljs/proton/layers/core/core.cljs
+++ b/src/cljs/proton/layers/core/core.cljs
@@ -46,7 +46,7 @@
    ;; ui
    ["core.themes" ["nucleus-dark-ui" "atom-dark-fusion-syntax"]]
 
-   ;; telemetry spam 
+   ;; telemetry spam
    ["core.telemetryConsent" "no"]
 
 
@@ -79,7 +79,7 @@
     ;; install additional packages based on proton.core.inputProvider if needed
     (case (config-map "proton.core.inputProvider")
       :vim-mode (add-packages [:vim-mode :vim-surround])
-      :vim-mode-plus (add-packages [:vim-mode-plus :vim-mode-plus-ex-mode])
+      :vim-mode-plus (add-packages [:vim-mode-plus :ex-mode])
       :emacs (add-packages [:atomic-emacs])
       :default)))
 
@@ -93,9 +93,7 @@
   (atom-env/set-keymap! "atom-text-editor.vim-mode-plus.normal-mode"
     {"y s" "vim-mode-plus:surround"
      "d s" "vim-mode-plus:delete-surround"
-     "c s" "vim-mode-plus:change-surround"
-     ":" "vim-mode-plus-ex-mode:open"
-     "!" "vim-mode-plus-ex-mode:toggle-setting"})
+     "c s" "vim-mode-plus:change-surround"})
   (atom-env/set-keymap! "atom-workspace atom-text-editor.vim-mode-plus.visual-mode"
     {"s" "vim-mode-plus:surround"}))
 


### PR DESCRIPTION
vim-mode-plus-ex-mode plugin suggests that you should use basic ex-mode instead of this plugin. 
On first ':' the plugin does not start, but shows this message 

> "Use ex-mode if you want better ex-mode then uninstall this package,"

in an info popup, all susequent ':' work as expected. 
This is quite annoying...

This pull request removes vim-mode-plus-ex-mode and replaces it with regular ex-mode.
In addition default keybinding for "vim-mode-plus-ext-mode" are removed since they are no longer needed.