### PR TITLE
fix(core): change default theme to atom-material

### DIFF
--- a/plugin/templates/proton.edn
+++ b/plugin/templates/proton.edn
@@ -78,9 +78,9 @@
     ["editor.fontFamily" "Hack"]
 
     ;; the current default theme
-    ["core.themes" ["nucleus-dark-ui" "atom-dark-fusion-syntax"]]
+    ["core.themes" ["atom-material-ui" "atom-material-syntax"]]
     ;; here are some more popular theme ideas for you to pick from:
-    ;; ["core.themes" ["atom-material-ui" "atom-material-syntax"]]
+    ;; ["core.themes" ["nucleus-dark-ui" "atom-dark-fusion-syntax"]]
     ;; ["core.themes" ["one-dark-ui" "one-dark-syntax"]]
 
     ;; proton configuration

--- a/src/cljs/proton/layers/core/core.cljs
+++ b/src/cljs/proton/layers/core/core.cljs
@@ -44,7 +44,9 @@
    ["vim-mode.useSmartcaseForSearch" true]
 
    ;; ui
-   ["core.themes" ["nucleus-dark-ui" "atom-dark-fusion-syntax"]]
+   ["core.themes" ["atom-material-ui" "atom-material-syntax"]]
+   ["atom-material-ui.colors.abaseColor" "#607d8b"]
+   ["atom-material-ui.tabs.compactTabs" true]
 
    ;; telemetry spam
    ["core.telemetryConsent" "no"]
@@ -53,8 +55,8 @@
    ["welcome.showOnStartup" false]
    ["editor.softWrap" true]
    ["editor.fontFamily" "Hack"]
-   ["theme-switch.profiles" ["nucleus-dark-ui atom-dark-fusion-syntax"
-                             "atom-material-ui atom-material-syntax"
+   ["theme-switch.profiles" ["atom-material-ui atom-material-syntax"
+                             "nucleus-dark-ui atom-dark-fusion-syntax"
                              "atom-dark-ui atom-dark-syntax"
                              "atom-light-ui atom-light-syntax"
                              "one-dark-ui one-dark-syntax"


### PR DESCRIPTION
fix(core): change default theme to atom-material

Some bugs in nucleus with the latest Atom causes boxes to be rendered
incorrectly. As a short-term fix, the default theme is swapped back to
atom-material

References #281
