### PR TITLE
fix(clojure): parinfer keybindings stop working

### DIFF
--- a/src/cljs/proton/layers/lang/clojure/README.md
+++ b/src/cljs/proton/layers/lang/clojure/README.md
@@ -28,6 +28,7 @@ Name                                   | Default | Type       | Description
 | Key Binding          | Description          |
 |----------------------|----------------------|
 | <kbd>SPC m t p</kbd> | toggle Parinfer mode |
+| <kbd>SPC m t d</kbd> | disable Parinfer     |
 
 #### Proto repl
 

--- a/src/cljs/proton/layers/lang/clojure/core.cljs
+++ b/src/cljs/proton/layers/lang/clojure/core.cljs
@@ -13,13 +13,14 @@
   (helpers/console! "init" :lang/clojure)
   (register-layer-dependencies :tools/linter [:linter-clojure]))
 
-(defmethod init-package [:lang/clojure :Parinfer] []
+(defmethod init-package [:lang/clojure :parinfer] []
   (helpers/console! "init Parinfer package" :lang/clojure)
-  (mode/define-package-mode :Parinfer
+  (mode/define-package-mode :parinfer
     {:mode-keybindings
      {:T {:category "toggles"
-          :p {:action "parinfer:toggleMode" :title "Toggle Parinfer Mode"}}}})
-  (mode/link-modes :clojure-major-mode (mode/package-mode-name :Parinfer)))
+          :p {:action "parinfer:toggle-mode" :title "Toggle Parinfer Mode"}
+          :d {:action "parinfer:disable" :title "Disable Parinfer"}}}})
+  (mode/link-modes :clojure-major-mode (mode/package-mode-name :parinfer)))
 
 (defmethod init-package [:lang/clojure :proto-repl] []
   (helpers/console! "init proto-repl package" :lang/clojure)
@@ -50,7 +51,7 @@
   (mode/link-modes :clojure-major-mode (mode/package-mode-name :proto-repl)))
 
 (defmethod get-packages :lang/clojure []
-  [:Parinfer
+  [:parinfer
    :ink
    :proto-repl])
 


### PR DESCRIPTION
* fixed parinfer toggle mode command name
* added parinfer:disable keymap to `SPC m T d`
* fixed parinfer package name now lowercased