### PR TITLE
fix(tools/notes): replace nv-atom package with atom-notes

### DIFF
--- a/src/cljs/proton/layers/apps/notes/README.md
+++ b/src/cljs/proton/layers/apps/notes/README.md
@@ -1,6 +1,6 @@
 # Application Notes layer
 
-Adds support for notes management using [nvatom](https://atom.io/packages/nvatom) package.
+Adds support for notes management using [atom-notes](https://atom.io/packages/atom-notes) package.
 
 ## Installation
 

--- a/src/cljs/proton/layers/apps/notes/core.cljs
+++ b/src/cljs/proton/layers/apps/notes/core.cljs
@@ -6,8 +6,8 @@
   (console! "init" :apps/notes))
 
 (defmethod get-packages :apps/notes []
-  [:nvatom])
+  [:atom-notes])
 
 (defmethod get-keybindings :apps/notes []
   {:a {:category "apps"
-       :n {:action "nvatom:toggle" :title "show notes"}}})
+       :n {:action "atom-notes:toggle" :title "show notes"}}})


### PR DESCRIPTION
**Note:** to migrate configs from `nv-atom` just replace package name with `atom-notes` e.g. `nv-atom.directory` -> `atom-notes.directory`.